### PR TITLE
Add `be_struct` matcher.

### DIFF
--- a/lib/espec/assertion_helpers.ex
+++ b/lib/espec/assertion_helpers.ex
@@ -67,6 +67,8 @@ defmodule ESpec.AssertionHelpers do
   end
   def be_nil, do: {ESpec.Assertions.BeType, :null}
   def be_function(arity), do: {ESpec.Assertions.BeType, [:function, arity]}
+  def be_struct, do: {ESpec.Assertions.BeType, :struct}
+  def be_struct(name), do: {ESpec.Assertions.BeType, [:struct, name]}
 
   def accepted(func, args \\ :any, opts \\ [pid: :any, count: :any]), do: {ESpec.Assertions.Accepted, [func, args, opts]}
 end

--- a/lib/espec/assertions/be_type.ex
+++ b/lib/espec/assertions/be_type.ex
@@ -16,6 +16,12 @@ defmodule ESpec.Assertions.BeType do
     {result, result}
   end
 
+  defp match(%{__struct__: actual}, [:struct, expected]) when actual == expected, do: {true, true}
+  defp match(_, [:struct, _expected]), do: {false, false}
+
+  defp match(%{__struct__: _}, :struct), do: {true, true}
+  defp match(_, :struct), do: {false, false}
+
   defp match(subject, type) do
     result = apply(Kernel, :"is_#{type}", [subject])
     {result, result}
@@ -30,6 +36,11 @@ defmodule ESpec.Assertions.BeType do
     to = if positive, do: "is", else: "is not"
     "`#{inspect subject}` #{to} `function` with arity `#{arity}`."
   end 
+
+  defp success_message(subject, [:struct, name], _result, positive) do
+    to = if positive, do: "is", else: "is not"
+    "`#{inspect subject}` #{to} struct named `#{name}`"
+  end
 
   defp success_message(subject, type, _result, positive) do
     to = if positive, do: "is", else: "is not"
@@ -46,6 +57,12 @@ defmodule ESpec.Assertions.BeType do
     to = if positive, do: "to", else: "to not"
     but = if positive, do: "isn't", else: "is"
     "Expected `#{inspect subject}` #{to} be function with arity `#{arity}` but it #{but}."
+  end
+
+  defp error_message(subject, [:struct, name], _result, positive) do
+    to = if positive, do: "to", else: "to not"
+    but = if positive, do: "isn't", else: "is"
+    "Expected `#{inspect subject}` #{to} be struct with name `#{name}` but it #{but}"
   end
 
   defp error_message(subject, type, _result, positive) do

--- a/spec/assertions/be_type_spec.exs
+++ b/spec/assertions/be_type_spec.exs
@@ -18,6 +18,8 @@ defmodule ESpec.Assertions.BeTypeSpec do
 		it do: make_ref |> should be_reference
 		it do: {:a, :b} |> should be_tuple
 		it do: fn(_a, _b) -> :ok end |> should be_function(2)
+                it do: HashDict.new |> should be_struct
+                it do: HashDict.new |> should be_struct(HashDict)
 	end
 
 	xcontext "Error" do
@@ -29,5 +31,8 @@ defmodule ESpec.Assertions.BeTypeSpec do
 
 		it do: fn(_a) -> :ok end |> should be_function(2)
 		it do: fn(_a, _b) -> :ok end |> should_not be_function(2)
+
+                it do: 1 |> should be_struct
+                it do: HashDict.new |> should_not be_struct
 	end
 end


### PR DESCRIPTION
Allows checking whether a term is a struct, and optionally that it is a
specific type of struct:

```elixir
defmodule StructExample do
  defstruct a: 1, b: 2
end

defmodule StructExampleSpec do
  use ESpec

  subject %StructExample{}

  it do: is_expected.to be_struct
  it do: is_expected.to be_struct(StructExample)
end
```