### PR TITLE
Handle `Configuration.get(:seed)` being integer

### DIFF
--- a/lib/espec/runner.ex
+++ b/lib/espec/runner.ex
@@ -182,12 +182,17 @@ defmodule ESpec.Runner do
 
   defp seed_random! do
     conf_seed = Configuration.get(:seed)
-    if conf_seed do
-      seed = String.to_integer(conf_seed)
-    else
-      seed =  :os.timestamp |> elem(2)
-      Configuration.add(seed: seed)
+
+    if conf_seed == nil do
+      conf_seed = :os.timestamp |> elem(2)
+      Configuration.add(seed: conf_seed)
     end
+
+    seed = case conf_seed do
+      seed when is_number(seed) -> seed
+      seed when is_binary(seed) -> String.to_integer(seed)
+    end
+
     :random.seed({3172, 9814, seed})
   end
 end


### PR DESCRIPTION
Previously, ESpec would crash when running recursively, as in the case
of an umbrella project because `:seed` would be stored as an integer,
then have `String.to_integer` called on it.

This handles `:seed` being `nil`, an integer, or a string.