### PR TITLE
Add --skip-examples option for espec.init

### DIFF
--- a/lib/mix/tasks/init.ex
+++ b/lib/mix/tasks/init.ex
@@ -6,14 +6,30 @@ defmodule Mix.Tasks.Espec.Init do
 
   @shortdoc "Create spec/spec_helper.exs and spec/example_spec.exs"
 
+  @moduledoc """
+  Creates neccessary files.
+
+  This tasks creates `spec/spec_helper.exs` and `spec/example_spec.exs`
+
+  ## Command line options
+
+  * `--skip-examples` - skip creating of example files
+
+  """
+
   @spec_folder "spec"
   @spec_helper "spec_helper.exs"
   @example_spec "example_spec.exs"
 
-  def run(_args) do
+  def run(args) do
+    {opts, _, _} = OptionParser.parse(args)
+
     create_directory @spec_folder
     create_file(Path.join(@spec_folder, @spec_helper), spec_helper_template(nil))
-    create_file(Path.join(@spec_folder, @example_spec), example_spec_template(nil))
+
+    unless opts[:skip_examples] do
+      create_file(Path.join(@spec_folder, @example_spec), example_spec_template(nil))
+    end
   end
 
   embed_template :spec_helper, """

--- a/test/mix/espec_init_test.exs
+++ b/test/mix/espec_init_test.exs
@@ -5,18 +5,28 @@ defmodule EspecInitTest do
 
   def clear, do: File.rm_rf! @tmp_path
 
-  setup do
+  setup context do
     Mix.shell(Mix.Shell.Process) # Get Mix output sent to the current process to avoid polluting tests.
-    function = fn -> Mix.Tasks.Espec.Init.run([]) end
+    if skip_examples = context[:skip_examples] do
+      function = fn -> Mix.Tasks.Espec.Init.run(["--skip-examples"]) end
+    else
+      function = fn -> Mix.Tasks.Espec.Init.run([]) end
+    end
     File.mkdir_p! @tmp_path
     File.cd! @tmp_path, function
     on_exit(&clear/0)
-    :ok   
+    :ok
   end
 
   test "check files" do
     assert File.regular?(Path.join(@tmp_path, "spec/spec_helper.exs"))
     assert File.regular?(Path.join(@tmp_path, "spec/example_spec.exs"))
+  end
+
+  @tag skip_examples: true
+  test "skip of examples" do
+    assert File.regular?(Path.join(@tmp_path, "spec/spec_helper.exs"))
+    refute File.regular?(Path.join(@tmp_path, "spec/example_spec.exs"))
   end
 
   test "spec_helper content" do


### PR DESCRIPTION
I added an option to espec.init task, to skip creation of examples.
If it is ok, I will make it for espec_phoenix as well.