### PR TITLE
Add `be_ok` and `be_error` assertions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,9 +403,16 @@ expect(function).to throw_term(term)
 ```
 #### Change state
 Test if call of function1 change the function2 returned value to smth or from to smth
-```elexir
+```elixir
 expect(function1).to change(function2, to)
-expect(function1).to change(function2, from, to) 
+expect(function1).to change(function2, from, to)
+```
+
+#### `:ok` and `:error` tuples.
+Test if the first element of a tuple begins has `:ok` or `:error` atoms.
+```elixir
+expect({:ok}) |> to(be_ok)
+expect({:error}) |> to(be_error)
 ```
 
 ## Custom matchers

--- a/lib/espec/assertion_helpers.ex
+++ b/lib/espec/assertion_helpers.ex
@@ -70,6 +70,9 @@ defmodule ESpec.AssertionHelpers do
   def be_struct, do: {ESpec.Assertions.BeType, :struct}
   def be_struct(name), do: {ESpec.Assertions.BeType, [:struct, name]}
 
+  def be_ok, do: {ESpec.Assertions.TupleFirstElement, :ok}
+  def be_error, do: {ESpec.Assertions.TupleFirstElement, :error}
+
   def accepted(func, args \\ :any, opts \\ [pid: :any, count: :any]), do: {ESpec.Assertions.Accepted, [func, args, opts]}
 end
 

--- a/lib/espec/assertions/tuple_first_element.ex
+++ b/lib/espec/assertions/tuple_first_element.ex
@@ -1,0 +1,18 @@
+defmodule ESpec.Assertions.TupleFirstElement do
+  use ESpec.Assertions.Interface
+
+  defp match(subject, expected) when is_tuple(subject) do
+    element = elem subject, 0
+    {element == expected, element}
+  end
+
+  defp success_message _subject, expected, actual, positive do
+    to = if positive, do: "equals", else: "doesn't equal"
+    "`#{inspect expected}` #{to} `#{inspect actual}`"
+  end
+
+  defp error_message _subject, expected, actual, positive do
+    to = if positive, do: "to", else: "not to"
+    "Expected `{#{inspect actual}, ...}` #{to} equal `{#{inspect expected}, ...}`"
+  end
+end

--- a/lib/espec/assertions/tuple_first_element.ex
+++ b/lib/espec/assertions/tuple_first_element.ex
@@ -1,6 +1,15 @@
 defmodule ESpec.Assertions.TupleFirstElement do
   use ESpec.Assertions.Interface
 
+  @moduledoc """
+  Defines 'be_ok' and 'be_error' assertions.
+
+  Matches the first element of a tuple.
+
+  it do: expect({:ok, ...}) |> to(be_ok)
+  it do: expect({:error, ...}) |> to(be_error)
+  """
+
   defp match(subject, expected) when is_tuple(subject) do
     element = elem subject, 0
     {element == expected, element}


### PR DESCRIPTION
This pull requests adds `be_ok` and `be_error` assertions which match the first element of a tuple.