### PR TITLE
Fix let (#84)

### DIFF
--- a/lib/espec.ex
+++ b/lib/espec.ex
@@ -33,7 +33,7 @@ defmodule ESpec do
 
       import ESpec.Before
       import ESpec.Finally
-      import ESpec.Let, except: [start_agent: 1, agent_get: 1, agent_put: 2]
+      import ESpec.Let, except: [start_agent: 0, stop_agent: 0, agent_get: 1, agent_put: 2, run_before: 2]
 
       import ExUnit.CaptureIO
     end

--- a/lib/espec.ex
+++ b/lib/espec.ex
@@ -33,7 +33,7 @@ defmodule ESpec do
 
       import ESpec.Before
       import ESpec.Finally
-      import ESpec.Let, except: [start_agent: 0, stop_agent: 0, agent_get: 1, agent_put: 2, run_before: 2]
+      import ESpec.Let
 
       import ExUnit.CaptureIO
     end
@@ -64,7 +64,7 @@ defmodule ESpec do
   def start do
     {:ok, _} = Application.ensure_all_started(:espec)
     start_specs_agent
-    ESpec.Let.start_agent
+    ESpec.Let.Impl.start_agent
     ESpec.Mock.start_agent
     ESpec.Output.start
   end
@@ -72,7 +72,7 @@ defmodule ESpec do
   @doc "Stops ESpec components"
   def stop do
     stop_specs_agent
-    ESpec.Let.stop_agent
+    ESpec.Let.Impl.stop_agent
     ESpec.Mock.stop_agent
     ESpec.Runner.stop
     ESpec.Output.stop

--- a/lib/espec/example_runner.ex
+++ b/lib/espec/example_runner.ex
@@ -175,17 +175,13 @@ defmodule ESpec.ExampleRunner do
     {map, example}
   end
 
-  defp do_run_befores_and_let(before_or_let, _example, map) do
-    case before_or_let.__struct__ do
-      ESpec.Before ->
-        before = before_or_let
-        returned = apply(before.module, before.function, [map])
-        fill_dict(map, returned)
-      ESpec.Let ->
-        let = before_or_let
-        ESpec.Let.agent_put({self, let.module, let.var}, apply(let.module, let.function, [map]))
-        map
-    end
+  defp do_run_befores_and_let(%ESpec.Let{} = let, _example, map) do
+    ESpec.Let.run_before(let, map)
+  end
+
+  defp do_run_befores_and_let(%ESpec.Before{} = before, _example, map) do
+    returned = apply(before.module, before.function, [map])
+    fill_dict(map, returned)
   end
 
   defp fill_dict(map, res) do

--- a/lib/espec/example_runner.ex
+++ b/lib/espec/example_runner.ex
@@ -176,7 +176,7 @@ defmodule ESpec.ExampleRunner do
   end
 
   defp do_run_befores_and_let(%ESpec.Let{} = let, _example, map) do
-    ESpec.Let.run_before(let, map)
+    ESpec.Let.Impl.run_before(let, map)
   end
 
   defp do_run_befores_and_let(%ESpec.Before{} = before, _example, map) do

--- a/lib/espec/let.ex
+++ b/lib/espec/let.ex
@@ -10,19 +10,17 @@ defmodule ESpec.Let do
   @doc "Struct keeps the name of variable and random function name."
   defstruct var: nil, module: nil, function: nil
 
-  @agent_name :espec_let_agent
-
   @doc """
   The macro defines funtion with random name which returns block value.
   That function will be called when example is run.
   The function will place the block value to the Agent dict.
   """
   defmacro let(var, do: block) do
-    function = random_let_name
+    function = ESpec.Let.Impl.random_let_name
 
     quote do
       tail = @context
-      head =  %ESpec.Let{var: unquote(var), module: __MODULE__, function: unquote(function)}
+      head = %ESpec.Let{var: unquote(var), module: __MODULE__, function: unquote(function)}
 
       def unquote(function)(var!(shared)) do
         var!(shared)
@@ -31,17 +29,10 @@ defmodule ESpec.Let do
 
       @context [head | tail]
 
-      unless ESpec.Let.agent_get({__MODULE__, "already_defined_#{unquote(var)}"}) do
+      unless Module.defines?(__MODULE__, {unquote(var), 0}, :def) do
         def unquote(var)() do
-          case ESpec.Let.agent_get({self, __MODULE__, unquote(var)}) do
-            {:todo, funcname, shared} ->
-              result = apply(__MODULE__, funcname, [shared])
-              ESpec.Let.agent_put({self, __MODULE__, unquote(var)}, {:done, result})
-              result
-            {:done, result} -> result
-          end
+          ESpec.Let.Impl.let_eval(__MODULE__, unquote(var))
         end
-        ESpec.Let.agent_put({__MODULE__, "already_defined_#{unquote(var)}"}, true)
       end
     end
   end
@@ -90,26 +81,40 @@ defmodule ESpec.Let do
     quote do: let!(unquote(var), do: unquote(block))
   end
 
-  @doc "Starts Agent to save state of 'lets'."
-  def start_agent, do: Agent.start_link(fn -> Map.new end, name: @agent_name)
+  defmodule Impl do
+    @agent_name :espec_let_agent
 
-  @doc "Stops Agent"
-  def stop_agent, do: Agent.stop(@agent_name)
+    @doc "This function is used by the let macro to implement lazy evaluation"
+    def let_eval(module, var) do
+      case agent_get({self, module, var}) do
+        {:todo, funcname, shared} ->
+          result = apply(module, funcname, [shared])
+          agent_put({self, module, var}, {:done, result})
+          result
+        {:done, result} ->
+          result
+      end
+    end
 
-  @doc "Get stored value."
-  def agent_get(key) do
-    dict = Agent.get(@agent_name, &(&1))
-    Map.get(dict, key)
+    @doc "Starts Agent to save state of 'lets'."
+    def start_agent, do: Agent.start_link(fn -> Map.new end, name: @agent_name)
+
+    @doc "Stops Agent"
+    def stop_agent, do: Agent.stop(@agent_name)
+
+    @doc "Resets stored let value and prepares for evaluation. Called by ExampleRunner."
+    def run_before(let, shared) do
+      agent_put({self, let.module, let.var}, {:todo, let.function, shared})
+      shared
+    end
+
+    defp agent_get(key) do
+      dict = Agent.get(@agent_name, &(&1))
+      Map.get(dict, key)
+    end
+
+    defp agent_put(key, value), do: Agent.update(@agent_name, &(Map.put(&1, key, value)))
+
+    def random_let_name, do: String.to_atom("let_#{ESpec.Support.random_string}")
   end
-
-  @doc "Store value."
-  def agent_put(key, value), do: Agent.update(@agent_name, &(Map.put(&1, key, value)))
-
-  @doc "Resets stored let value and prepares for evaluation. Called by ExampleRunner."
-  def run_before(let, shared) do
-    agent_put({self, let.module, let.var}, {:todo, let.function, shared})
-    shared
-  end
-
-  defp random_let_name, do: String.to_atom("let_#{ESpec.Support.random_string}")
 end

--- a/spec/let_spec.exs
+++ b/spec/let_spec.exs
@@ -50,11 +50,6 @@ defmodule LetSpec do
       let :a, do: shared[:a] + 1
       it do: expect(a).to eq(2)
     end
-
-    context "let runs only when called" do
-      let :b, do: IO.puts("You will not see it")
-      it do: expect(1).to eq(1)
-    end
   end
 
   describe "let use let" do
@@ -62,5 +57,19 @@ defmodule LetSpec do
     let :b, do: a + 1
 
     it do: b |> should(eq 2)
+  end
+
+  describe "let is lazy and memoizes" do
+    let :a do
+      value = Application.get_env(:espec, :let_value, "") <> ".let"
+      Application.put_env(:espec, :let_value, value)
+      value
+    end
+
+    it do
+      Application.put_env(:espec, :let_value, "initial")
+      expect(a).to eq("initial.let")
+      expect(a).to eq("initial.let")
+    end
   end
 end


### PR DESCRIPTION
This rework of the `let` implementation should fix #84 . It passes that test case (easily, since there is no longer any use of `Code.eval_quoted`) and does not break any existing test.

Technical details are in the commit logs. I hope this patch is useful, please let me know if anything needs improvement.