### PR TITLE
Make let! work again (fix #86)

### DIFF
--- a/lib/espec/example.ex
+++ b/lib/espec/example.ex
@@ -41,7 +41,8 @@ defmodule ESpec.Example do
   def pendings(results), do: Enum.filter(results, &(&1.status === :pending))
 
   @doc "Extracts specific structs from example context."
-  def extract_befores_and_lets(example), do: extract(example.context, [ESpec.Before, ESpec.Let])
+  def extract_befores(example), do: extract(example.context, [ESpec.Before])
+  def extract_lets(example), do: extract(example.context, [ESpec.Let])
   def extract_finallies(example), do: extract(example.context, [ESpec.Finally])
   def extract_contexts(example), do: extract(example.context, [ESpec.Context])
 

--- a/spec/let_spec.exs
+++ b/spec/let_spec.exs
@@ -19,7 +19,36 @@ defmodule LetSpec do
       it do: expect(a).to eq(2)
     end
 
-    context "let! performs like let with before" do
+    context "forces evaluation before examples" do
+      let! :test do
+        Application.put_env(:espec, :letbang_value, "let!")
+        456
+      end
+
+      it "has run before example" do
+        value = Application.get_env(:espec, :letbang_value, "")
+        expect value |> to(eq "let!")
+        expect test |> to(eq 456)
+      end
+    end
+
+    context "when overridden, is used by before" do
+      let! :test, do: "initial"
+
+      before do
+        expect test |> to(eq "overridden")
+      end
+
+      context "some context" do
+        let! :test, do: "overridden"
+
+        it "equals 131" do
+          expect test |> to(eq "overridden")
+        end
+      end
+    end
+
+    context "when overridden, is used by other let! declarations, even in parent contexts" do
       let! :test, do: 123
       let! :test2, do: test + 1
 


### PR DESCRIPTION
This restores `let!` functionality (evaluate block in a `before` block) and adds a test for it. See the commit log for the gory details. Sorry again for breaking it. Hopefully this does not add more breakage, but having been burned once, I can't say I'm entirely confident.

I'm not really happy with how the shared state is now "magically" passed to those `let` blocks. We now have complicated code to basically simulate mutable variables in Elixir :worried:

I don't have a better idea however for making complicated cases like #82 work as expected, while handling the various possible interactions of shared state and lazily evaluated functions…