### PR TITLE
Remove all duplicate funcs when assignment present

### DIFF
--- a/lib/espec/let/quote_analyzer.ex
+++ b/lib/espec/let/quote_analyzer.ex
@@ -1,7 +1,7 @@
 defmodule ESpec.Let.QuoteAnalyzer do
   def function_list(ast) do
-    {funcs, assigments} = Enum.partition(parse(ast, []), fn {key, value} -> key == :fun end)
-    Enum.uniq(Keyword.values(funcs) -- Keyword.values(assigments))
+    {funcs, assignments} = Enum.partition(parse(ast, []), fn {key, _value} -> key == :fun end)
+    Enum.uniq(Keyword.values(funcs)) -- Enum.uniq(Keyword.values(assignments))
   end
 
   defp parse({:|>, _, [ast_left, {ast, context, args}]}, fun_list) do


### PR DESCRIPTION
Sometimes there are more functions with a given name in the funcs list,
but most commonly only a single assignment with that name is found.

Running `Enum.uniq` on both lists before `--` reduces the amount of
leaking `let`s a bit, but not completely.

Haven't found a minimal test case, so I just refer to my broken build:

- Travis CI: https://travis-ci.org/edib-tool/mix-edib/builds/130218530
- Commit: https://github.com/edib-tool/mix-edib/commit/6d1ad4d41a46b01270e3d982933b329b5270f103

With this change applied as patch I get down from 18 to 5 failures:

- Travis CI: https://travis-ci.org/edib-tool/mix-edib/builds/130245382
- Commit: https://github.com/edib-tool/mix-edib/commit/157d7caea52e0b09d485b0629d8921b18f76f498

-----

Maybe you have an idea what else needs to be fixed to get rid of the remaining false-positive leaks?