### PR TITLE
Adds a fun_arity for tests found in moduledocs.

### DIFF
--- a/lib/espec/doc_example.ex
+++ b/lib/espec/doc_example.ex
@@ -57,7 +57,9 @@ defmodule ESpec.DocExample do
   defp extract_from_moduledoc({_, doc}) when doc in [false, nil], do: []
 
   defp extract_from_moduledoc({line, doc}) do
-    extract_tests(line, doc)
+    for test <- extract_tests(line, doc) do
+      %{test | fun_arity: {:moduledoc, 0}}
+    end
   end
 
   defp extract_from_doc({_, _, _, _, doc}) when doc in [false, nil], do: []

--- a/test/docs/doc_test_test.exs
+++ b/test/docs/doc_test_test.exs
@@ -1,4 +1,9 @@
 defmodule ESpec.DocTestTest.Mod1 do
+  @moduledoc """
+    iex> 2 + 2
+    4
+  """
+
   @doc """
     iex> Enum.map [1, 2, 3], fn(x) ->
     ...>   x * 2
@@ -29,25 +34,33 @@ defmodule ESpec.Docs.DocTestTest do
       ex1: Enum.at(examples, 0),
       ex2: Enum.at(examples, 1),
       ex3: Enum.at(examples, 2),
+      ex4: Enum.at(examples, 3)
     }
   end
 
   test "ex1", context do
     ex = ESpec.ExampleRunner.run(context[:ex1])
-    assert ex.description =~ "Doctest for Elixir.ESpec.DocTestTest.Mod1.f/0"
+    assert ex.description =~ "Doctest for Elixir.ESpec.DocTestTest.Mod1.moduledoc/0"
     assert ex.status == :success
-    assert ex.result == "`[2, 4, 6]` equals `[2, 4, 6]`."
+    assert ex.result == "`4` equals `4`."
   end
 
   test "ex2", context do
     ex = ESpec.ExampleRunner.run(context[:ex2])
     assert ex.description =~ "Doctest for Elixir.ESpec.DocTestTest.Mod1.f/0"
-    assert ex.status == :failure
-    assert ex.error.message == "Expected `4` to equals (==) `5`, but it doesn't."
+    assert ex.status == :success
+    assert ex.result == "`[2, 4, 6]` equals `[2, 4, 6]`."
   end
 
   test "ex3", context do
     ex = ESpec.ExampleRunner.run(context[:ex3])
+    assert ex.description =~ "Doctest for Elixir.ESpec.DocTestTest.Mod1.f/0"
+    assert ex.status == :failure
+    assert ex.error.message == "Expected `4` to equals (==) `5`, but it doesn't."
+  end
+
+  test "ex4", context do
+    ex = ESpec.ExampleRunner.run(context[:ex4])
     assert ex.status == :success
     assert ex.result == "`:f` equals `:f`."
   end


### PR DESCRIPTION
### Issue

When trying to include moduledocs as part of doctests using ESpec, it would return this error

```
** (MatchError) no match of right hand side value: nil
    spec/forte/duration_spec.exs:4: anonymous fn/2 in :elixir_compiler_6.__MODULE__/1
    (elixir) lib/enum.ex:1623: Enum."-reduce/3-lists^foldl/2-0-"/3
    spec/forte/duration_spec.exs:4: (module)
    (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
```

The problem was that `fun_arity` was being set to `nil` for tests extracted from moduledocs, rather than the `{:fun_name, arity}` tuple that was expected.

### Solution

This PR sets `fun_arity` for tests extracted from moduledocs to `{:moduledoc, 0}`, so that they can be correctly tested by ESpec, and can also be passed to the `only:` and `except:` options for the `moduledoc` macro.