### PR TITLE
Add blank/empty assertions for strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ defmodule SomeSpec do
 
     finally do: "This finally will not be run. Define 'finally' before the example"
   end
-end  
+end
 ```
 Note, that `finally` blocks must be defined before the example.
 You can configure 'global' `before` and `finally` in `spec_helper.exs`:
@@ -245,7 +245,7 @@ ESpec.start
 
 ESpec.configure fn(config) ->
   config.before fn -> {:shared, answer: 42} end         # shared == %{anwser: 42}
-  config.finally fn(shared) -> IO.puts shared.answer  end    # it will print 46   
+  config.finally fn(shared) -> IO.puts shared.answer  end    # it will print 46
 end
 ```
 `some_spec.exs`:
@@ -253,7 +253,7 @@ end
 defmodule SomeSpec do
   use ESpec
 
-  before do: {:shared, answer: shared.answer + 1}          # shared == %{anwser: 43}       
+  before do: {:shared, answer: shared.answer + 1}          # shared == %{anwser: 43}
   finally do: {:shared, answer: shared.answer + 1}         # shared == %{anwser: 46}
 
   context do
@@ -280,7 +280,7 @@ defmodule SomeSpec do
 
   it do: expect a |> to(eq 1)
   it do: expect b |> to(eq 2)
-end  
+end
 ```
 `subject` and `subject!` are just aliases for `let :subject, do: smth` and `let! :subject, do: smth`. You can use `is_expected` macro (or a simple `should` expression) when `subject` is defined.
 ```elixir
@@ -438,13 +438,15 @@ expect string |> to(have_first value)  #String.first(string) == value
 ... have_last value                   #String.last(string) == value
 ... start_with value                  #String.starts_with?(string, value)
 ... end_with value                    #String.end_with?(string, value)
-... have value                        #String.contains?(string, value)    
+... have value                        #String.contains?(string, value)
 ... have_at pos, value                #String.at(string, pos) == value
-... have_length value                 #Stirng.length(string) == value
+... have_length value                 #String.length(string) == value
 ... have_size value                   #alias
 ... have_count value                  #alias
 ... be_valid_string                   #String.valid?(string)
 ... be_printable                      #String.printable?(string)
+... be_blank                          #String.length(string) == 0
+... be_empty                          #String.length(string) == 0
 ```
 #### Dict
 ```elixir
@@ -601,7 +603,7 @@ defmodule SomeSpec do
   it "raises exception when does not match" do
     expect(fn -> SomeModule.func({:wrong, :args}) end)
     |> to(raise_exception FunctionClauseError)
-  end  
+  end
 end
 ```
 Behind the scenes 'allow accept' makes the following:
@@ -649,7 +651,7 @@ defmodule SomeSpec do
   before do
     allow SomeModule |> to(accept :func, fn(a,b) -> a+b end)
     SomeModule.func(1, 2)
-  end  
+  end
 
   it do: expect SomeModule |> to(accepted :func)
   it do: expect SomeModule |> to(accepted :func, [1,2])
@@ -715,7 +717,7 @@ The functionality is implemented by two modules:
 defmodule SomeSpec do
   use ESpec
   doctest MySuperModule
-end  
+end
 ```
 There are three options (similar to `ExUnit.DocTest`):
 
@@ -724,7 +726,7 @@ There are three options (similar to `ExUnit.DocTest`):
 defmodule SomeSpec do
   use ESpec
   doctest MySuperModule, except: [fun: 1, func: 2]
-end  
+end
 ```
 `:only` — generate specs only for functions listed (list of {function, arity} tuples).
 
@@ -740,12 +742,12 @@ iex> Enum.map [1, 2, 3], fn(x) ->
 ...> end
 [2,4,6]
 """
-```  
+```
 Such examples will be converted to:
 ```elixir
 it "Example description" do
   expect input |> to(eq output)
-end  
+end
 ```
 - Examples which return complex structure so Elixir prints it as `#Name<...>.`:
 ```elixir

--- a/lib/espec/assertion_helpers.ex
+++ b/lib/espec/assertion_helpers.ex
@@ -59,6 +59,7 @@ defmodule ESpec.AssertionHelpers do
   def end_with(value), do: {Assertions.String.EndWith, value}
   def be_printable(), do: {Assertions.String.BePrintable, []}
   def be_valid_string(), do: {Assertions.String.BeValidString, []}
+  def be_blank(), do: {Assertions.String.BeBlank, []}
 
   def have_key(value), do: {Assertions.Dict.HaveKey, value}
   def have_value(value), do: {Assertions.Dict.HaveValue, value}

--- a/lib/espec/assertions/enum/be_empty.ex
+++ b/lib/espec/assertions/enum/be_empty.ex
@@ -3,8 +3,14 @@ defmodule ESpec.Assertions.Enum.BeEmpty do
   Defines 'be_empty' assertion.
 
   it do: expect(collection).to be_empty
+  it do: expect(string).to be_empty
   """
   use ESpec.Assertions.Interface
+
+  defp match(string, _data) when is_bitstring(string) do
+    result = String.length(string)
+    {result == 0, result}
+  end
 
   defp match(enum, _data) do
     result = Enum.count(enum)

--- a/lib/espec/assertions/string/be_blank.ex
+++ b/lib/espec/assertions/string/be_blank.ex
@@ -1,0 +1,24 @@
+defmodule ESpec.Assertions.String.BeBlank do
+  @moduledoc """
+  Defines 'be_blank' assertion.
+
+  it do: expect(string).to be_blank
+  """
+  use ESpec.Assertions.Interface
+
+  defp match(string, _val) do
+    result = String.length(string) == 0
+    {result, result}
+  end
+
+  defp success_message(string, _val, _result, positive) do
+    to = if positive, do: "is", else: "is not"
+    "`#{inspect string}` #{to} blank."
+  end
+
+  defp error_message(string, _val, _result, positive) do
+    to = if positive, do: "to", else: "not to"
+    but = if positive, do: "it isn't", else: "it is"
+    "Expected `#{inspect string}` #{to} be blank but #{but}."
+  end
+end

--- a/spec/assertions/enum/be_empty_spec.exs
+++ b/spec/assertions/enum/be_empty_spec.exs
@@ -2,38 +2,78 @@ defmodule ESpec.Assertions.Enum.BeEmptySpec do
   use ESpec, async: true
 
   context "Success" do
-    it "checks success with `to`" do
-      message = expect([]).to be_empty
-      expect(message) |> to(eq "`[]` is empty.")
+    context "testing a collection" do
+      it "checks success with `to`" do
+        message = expect([]).to be_empty
+        expect(message) |> to(eq "`[]` is empty.")
+      end
+
+      it "checks success with `not_to`" do
+        message = expect([1,2,3]).to_not be_empty
+        expect(message) |> to(eq "`[1, 2, 3]` is not empty.")
+      end
     end
 
-    it "checks success with `not_to`" do
-      message = expect([1,2,3]).to_not be_empty
-      expect(message) |> to(eq "`[1, 2, 3]` is not empty.")
+    context "testing a string" do
+      it "checks success with `to`" do
+        message = expect("").to be_empty
+        expect(message) |> to(eq "`\"\"` is empty.")
+      end
+
+      it "checks success with `not_to`" do
+        message = expect("hello").to_not be_empty
+        expect(message) |> to(eq "`\"hello\"` is not empty.")
+      end
     end
   end
 
   context "Error" do
-    context "with `to`" do
-      before do
-        { :shared,
-          expectation: fn -> expect([1,2,3]).to be_empty end,
-          message: "Expected `[1, 2, 3]` to be empty, but it has `3` elements."
-        }
+    context "testing a collection" do
+      context "with `to`" do
+        before do
+          { :shared,
+            expectation: fn -> expect([1,2,3]).to be_empty end,
+            message: "Expected `[1, 2, 3]` to be empty, but it has `3` elements."
+          }
+        end
+
+        it_behaves_like(CheckErrorSharedSpec)
       end
 
-      it_behaves_like(CheckErrorSharedSpec)
+      context "with `not_to`" do
+        before do
+          { :shared,
+            expectation: fn -> expect([]).to_not be_empty end,
+            message: "Expected `[]` not to be empty, but it is."
+          }
+        end
+
+        it_behaves_like(CheckErrorSharedSpec)
+      end
     end
 
-    context "with `not_to`" do
-      before do
-        { :shared,
-          expectation: fn -> expect([]).to_not be_empty end,
-          message: "Expected `[]` not to be empty, but it is."
-        }
+    context "testing a string" do
+      context "with `to`" do
+        before do
+          { :shared,
+            expectation: fn -> expect("qwerty").to be_empty end,
+            message: "Expected `\"qwerty\"` to be empty, but it has `6` elements."
+          }
+        end
+
+        it_behaves_like(CheckErrorSharedSpec)
       end
 
-      it_behaves_like(CheckErrorSharedSpec)
+      context "with `not_to`" do
+        before do
+          { :shared,
+            expectation: fn -> expect("").to_not be_empty end,
+            message: "Expected `\"\"` not to be empty, but it is."
+          }
+        end
+
+        it_behaves_like(CheckErrorSharedSpec)
+      end
     end
   end
 end

--- a/spec/assertions/string/be_blank_spec.exs
+++ b/spec/assertions/string/be_blank_spec.exs
@@ -1,0 +1,39 @@
+defmodule ESpec.Assertions.String.BeBlankSpec do
+  use ESpec, async: true
+
+  context "Success" do
+    it "checks success with `to`" do
+      message = "" |> should(be_blank)
+      expect(message) |> to(eq "`\"\"` is blank.")
+    end
+
+    it "checks success with `not_to`" do
+      message = "qwerty" |> should_not(be_blank)
+      expect(message) |> to(eq "`\"qwerty\"` is not blank.")
+    end
+  end
+
+  context "Error" do
+    context "with `to`" do
+      before do
+        { :shared,
+          expectation: fn -> "qwerty" |> should(be_blank) end,
+          message: "Expected `\"qwerty\"` to be blank but it isn't."
+        }
+      end
+
+      it_behaves_like(CheckErrorSharedSpec)
+    end
+
+    context "with `not_to`" do
+      before do
+        { :shared,
+          expectation: fn -> "" |> should_not(be_blank) end,
+          message: "Expected `\"\"` not to be blank but it is."
+        }
+      end
+
+      it_behaves_like(CheckErrorSharedSpec)
+    end
+  end
+end

--- a/test/assertions/string/be_blank_test.exs
+++ b/test/assertions/string/be_blank_test.exs
@@ -1,29 +1,27 @@
-defmodule Enum.BeEmptyTest do
+defmodule String.BeBlankTest do
   use ExUnit.Case, async: true
 
   defmodule SomeSpec do
     use ESpec
 
+    subject "qwerty"
+
     context "Success" do
-      it do: expect([]).to be_empty
-      it do: expect([1,2,3]).to_not be_empty
-      it do: expect("").to be_empty
-      it do: expect("qwerty").to_not be_empty
+      it do: "" |> should(be_blank)
+      it do: "qwerty" |> should_not(be_blank)
     end
 
     context "Error" do
-      it do: expect([]).to_not be_empty
-      it do: expect([1,2,3]).to be_empty
-      it do: expect("").to_not be_empty
-      it do: expect("qwerty").to be_empty
+      it do: "" |> should_not(be_blank)
+      it do: "qwerty" |> should(be_blank)
     end
   end
 
   setup_all do
     examples = ESpec.Runner.run_examples(SomeSpec.examples)
     { :ok,
-      success: Enum.slice(examples, 0, 3),
-      errors: Enum.slice(examples, 4, 7)
+      success: Enum.slice(examples, 0, 1),
+      errors: Enum.slice(examples, 2, 3)
     }
   end
 


### PR DESCRIPTION
* Adds `be_blank`
* Extends `be_empty` to check against strings as well as collections

References https://github.com/antonmi/espec/issues/126