### PR TITLE
Use :rand instead of :random which is deprecated

### DIFF
--- a/lib/espec/runner.ex
+++ b/lib/espec/runner.ex
@@ -198,6 +198,6 @@ defmodule ESpec.Runner do
       is_binary(conf_seed) -> String.to_integer(conf_seed)
     end
 
-    :random.seed({3172, 9814, seed})
+    :rand.seed(:exs64, {3172, 9814, seed})
   end
 end


### PR DESCRIPTION
OTP 19.0
```
warning: random:seed/1: the 'random' module is deprecated; use the 'rand' module instead
  lib/espec/runner.ex:201
```
http://erlang.org/doc/man/rand.html