### PR TITLE
Implement have_byte_size

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,10 @@ expect list |> to(have_first value)  #List.first(list) == value
 ... have_hd value                   #hd(list) == value
 ... have_tl value                   #tl(list) == value
 ```
+#### Binary
+```elixir
+expect binary |> to(have_byte_size value) #byte_size(binary) == value
+```
 #### String
 ```elixir
 expect string |> to(have_first value)  #String.first(string) == value

--- a/lib/espec/assertion_helpers.ex
+++ b/lib/espec/assertion_helpers.ex
@@ -56,6 +56,8 @@ defmodule ESpec.AssertionHelpers do
   def have_hd(value), do: {Assertions.List.HaveHd, value}
   def have_tl(value), do: {Assertions.List.HaveTl, value}
 
+  def have_byte_size(value), do: {Assertions.Binary.HaveByteSize, value}
+
   def start_with(value), do: {Assertions.String.StartWith, value}
   def end_with(value), do: {Assertions.String.EndWith, value}
   def be_printable(), do: {Assertions.String.BePrintable, []}

--- a/lib/espec/assertions/binary/have_byte_size.ex
+++ b/lib/espec/assertions/binary/have_byte_size.ex
@@ -1,0 +1,23 @@
+defmodule ESpec.Assertions.Binary.HaveByteSize do
+  @moduledoc """
+  Defines 'have_byte_size' assertion.
+
+  it do: expect(binary).to have_byte_size(value)
+  """
+  use ESpec.Assertions.Interface
+
+  defp match(binary, val) when is_binary(binary) do
+    result = byte_size(binary)
+    {result == val, result}
+  end
+
+  defp success_message(enum, val, _result, positive) do
+    to = if positive, do: "has", else: "doesn't have"
+    "`#{inspect enum}` #{to} `#{val}` byte(s)."
+  end
+
+  defp error_message(enum, val, result, positive) do
+    to = if positive, do: "to", else: "not to"
+    "Expected `#{inspect enum}` #{to} have `#{val}` byte(s) but it has `#{result}`."
+  end
+end

--- a/spec/assertions/binary/have_byte_size_spec.exs
+++ b/spec/assertions/binary/have_byte_size_spec.exs
@@ -1,0 +1,42 @@
+defmodule ESpec.Assertions.Binary.HaveByteSizeSpec do
+  use ESpec, async: true
+
+  let :byte_count, do: byte_size(binary)
+  let :binary, do: <<116, 188, 252, 155, 9>>
+
+  context "Success" do
+    it "checks success with `to`" do
+      message = expect(binary).to have_byte_size(byte_count)
+      expect(message) |> to(eq "`<<116, 188, 252, 155, 9>>` has `#{byte_count}` byte(s).")
+    end
+
+    it "checks success with `not_to`" do
+      message = expect(binary).to_not have_byte_size(byte_count - 1)
+      expect(message) |> to(eq "`<<116, 188, 252, 155, 9>>` doesn't have `#{byte_count - 1}` byte(s).")
+    end
+  end
+
+  context "Error" do
+    context "with `to`" do
+      before do
+        { :shared,
+          expectation: fn -> expect(binary).to have_byte_size(byte_count - 1) end,
+          message: "Expected `<<116, 188, 252, 155, 9>>` to have `#{byte_count - 1}` byte(s) but it has `#{byte_count}`."
+        }
+      end
+
+      it_behaves_like(CheckErrorSharedSpec)
+    end
+
+    context "with `not_to`" do
+      before do
+        { :shared,
+          expectation: fn -> expect(binary).to_not have_byte_size(byte_count) end,
+          message: "Expected `<<116, 188, 252, 155, 9>>` not to have `#{byte_count}` byte(s) but it has `#{byte_count}`."
+        }
+      end
+
+      it_behaves_like(CheckErrorSharedSpec)
+    end
+  end
+end

--- a/test/assertions/binary/have_byte_size_test.exs
+++ b/test/assertions/binary/have_byte_size_test.exs
@@ -1,0 +1,36 @@
+defmodule Binary.HaveByteSizeTest do
+  use ExUnit.Case, async: true
+
+  defmodule SomeSpec do
+    use ESpec
+
+    let :byte_count, do: byte_size(binary)
+    let :binary, do: <<116, 188, 252, 155, 9>>
+
+    context "Success" do
+      it do: expect(binary).to have_byte_size(byte_count)
+      it do: expect(binary).to_not have_byte_size(byte_count - 1)
+    end
+
+    context "Error" do
+      it do: expect(binary).to_not have_byte_size(byte_count)
+      it do: expect(binary).to have_byte_size(byte_count - 1)
+    end
+  end
+
+  setup_all do
+    examples = ESpec.Runner.run_examples(SomeSpec.examples)
+    { :ok,
+      success: Enum.slice(examples, 0, 1),
+      errors: Enum.slice(examples, 2, 3)
+    }
+  end
+
+  test "Success", context do
+    Enum.each(context[:success], &(assert(&1.status == :success)))
+  end
+
+  test "Errors", context do
+    Enum.each(context[:errors], &(assert(&1.status == :failure)))
+  end
+end


### PR DESCRIPTION
This uses `byte_size(binary)` to test the actual byte size of the binary (as opposed to `String.length` which tests for the UTF-8-encoded character count).