### PR TITLE
(Failing spec) Fetched before_finally_spec from README

### DIFF
--- a/spec/before_finally_order_spec.exs
+++ b/spec/before_finally_order_spec.exs
@@ -1,0 +1,27 @@
+defmodule BeforeFinallyOrderSpec do
+  use ESpec
+
+  before do
+    expect(shared.answer).to eq(42)
+    {:shared, answer: (shared.answer + 1)} # shared == %{anwser: 43}
+  end
+
+  finally do
+    expect(shared.answer).to eq(45)
+    {:shared, answer: (shared.answer + 1)} # shared == %{anwser: 46}
+  end
+
+  context do
+    before do
+      expect(shared.answer).to eq(43)
+      {:shared, answer: shared.answer + 1} # shared == %{anwser: 44}
+    end
+
+    finally do
+      expect(shared.answer).to eq(44)
+      {:shared, answer: shared.answer + 1} # shared == %{anwser: 45}
+    end
+
+    it do: shared.answer |> should(eq 44)
+  end
+end


### PR DESCRIPTION
The spec shows that the [behavior described in README](https://github.com/antonmi/espec#shared-data)(I just renamed the spec) is broken.
>Pay attention to how finally blocks are defined and evaluated.

Is this a regression?