### PR TITLE
Added support for unicode in example names

### DIFF
--- a/lib/espec/support.ex
+++ b/lib/espec/support.ex
@@ -9,7 +9,14 @@ defmodule ESpec.Support do
   @doc "Filters string replacing non-word characters by '_'."
   def word_chars(string) do
     string
+    |> remove_unicode
     |> String.replace(~r/[\W+\d+\s+]/, "_")
     |> String.downcase
+  end
+
+  defp remove_unicode(string) do
+    string
+    |> String.normalize(:nfd)
+    |> String.replace(~r/[^A-z\s]/u, "")
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -2,4 +2,4 @@
   "credo": {:hex, :credo, "0.4.11", "03a64e9d53309b7132556284dda0be57ba1013885725124cfea7748d740c6170", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]},
   "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:rebar, :make], []}}
+  "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:make, :rebar], []}}

--- a/test/examples/example_test.exs
+++ b/test/examples/example_test.exs
@@ -15,6 +15,9 @@ defmodule ExampleTest do
       "it is with name"
     end
 
+    example "example with unicode letters áéíóúàèìòùäëïöü" do
+    end
+
     specify do: "another example"
     specify "name", do: "another example"
     specify "name", [], do: "another example"
@@ -25,12 +28,13 @@ defmodule ExampleTest do
       ex1: Enum.at(SomeSpec.examples, 0),
       ex2: Enum.at(SomeSpec.examples, 1),
       ex3: Enum.at(SomeSpec.examples, 2),
-      ex4: Enum.at(SomeSpec.examples, 3)
+      ex4: Enum.at(SomeSpec.examples, 3),
+      unicode: Enum.at(SomeSpec.examples, 4)
     }
   end
 
   test "check SomeSpec.examples length" do
-    assert(length(SomeSpec.examples) == 7)
+    assert(length(SomeSpec.examples) == 8)
   end
 
   test "check ex1", context do
@@ -67,5 +71,9 @@ defmodule ExampleTest do
 
   test "ex4 opts", context do
     assert(context[:ex4].opts == [c: 3])
+  end
+
+  test "check unicode example", context do
+    assert(context[:unicode].description == "example with unicode letters áéíóúàèìòùäëïöü")
   end
 end

--- a/test/support_test.exs
+++ b/test/support_test.exs
@@ -9,6 +9,11 @@ defmodule SupportTest do
 
   test "word_chars" do
     string = ESpec.Support.word_chars("123  $@$#%$ ok")
-    assert string ==  "____________ok"
+    assert string ==  "___ok"
+  end
+
+  test "word_chars with unicode" do
+    string = ESpec.Support.word_chars("áéíóúàèìòùäëïöü ok")
+    assert string == "aeiouaeiouaeiou_ok"
   end
 end


### PR DESCRIPTION
Hello. I've noticed that ESpec crashes when you use non-ascii characters in the example name, so here's my proposed solution with some tests.