### PR TITLE
Remove obsolete variable usage in ExampleRunner

### DIFF
--- a/lib/espec/example_runner.ex
+++ b/lib/espec/example_runner.ex
@@ -196,7 +196,7 @@ defmodule ESpec.ExampleRunner do
       example
     else
       error = %AssertionError{message: format_other_error(error)}
-      example = %Example{example | status: :failure, error: error}
+      %Example{example | status: :failure, error: error}
     end
     {map, example}
   end


### PR DESCRIPTION
This fixes warning in Elixir 1.3.4.