### PR TITLE
Bump credo version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule ESpec.Mixfile do
   defp deps do
     [
       {:meck, "~> 0.8.4"},
-      {:credo, "0.4.11", only: :dev},
+      {:credo, "~> 0.4", only: :dev},
       # Docs
       {:earmark, "~> 1.0.1", only: [:docs, :dev]},
       {:ex_doc, "~> 0.13.0", only: [:docs, :dev]}

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},
-  "credo": {:hex, :credo, "0.4.11", "03a64e9d53309b7132556284dda0be57ba1013885725124cfea7748d740c6170", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]},
-  "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
+  "credo": {:hex, :credo, "0.5.2", "92e8c9f86e0ffbf9f688595e9f4e936bc96a52e5606d2c19713e9e4d191d5c74", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]},
+  "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.13.2", "1059a588d2ad3ffab25a0b85c58abf08e437d3e7a9124ac255e1d15cec68ab79", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:make, :rebar], []}}


### PR DESCRIPTION
On the current `master` credo didn't work for me: it failed with an error:

```
Compiling 120 files (.ex)
warning: variable new_issues is unused
  lib/credo/check/consistency/helper.ex:118

warning: variable line is unused
  lib/credo/cli/output/explain.ex:130

warning: function Hex.Utils.ensure_registry!/0 is undefined or private
  lib/credo/check_for_updates.ex:4

warning: function Hex.Registry.get_versions/1 is undefined or private
  lib/credo/check_for_updates.ex:9

Generated credo app
** (UndefinedFunctionError) function Hex.Utils.ensure_registry!/0 is undefined or private
    (hex) Hex.Utils.ensure_registry!()
    lib/credo/check_for_updates.ex:4: Credo.CheckForUpdates.run/0
    lib/credo/cli.ex:92: Credo.CLI.run/1
    lib/credo/cli.ex:58: Credo.CLI.main/1
    (mix) lib/mix/task.ex:296: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:58: Mix.CLI.run_task/2
```

Bumping credo version fixed the problem. Also, Using `~> 0.4` is the way to go according to [credo docs](https://github.com/rrrene/credo#installation).

Also, other dependencies (**earmark** and **ex_doc**) got a minor version bump.