### PR TITLE
Add default handle_info implementation for runner.ex

### DIFF
--- a/lib/espec/runner.ex
+++ b/lib/espec/runner.ex
@@ -40,6 +40,11 @@ defmodule ESpec.Runner do
     {:stop, :normal, :ok, []}
   end
 
+  @doc false
+  def handle_info(_msg, state) do
+    {:noreply, state}
+  end
+
   defp do_run(specs, opts) do
     examples = if Configuration.get(:order) do
       run_suites(specs, opts, false)


### PR DESCRIPTION
A warning was added in the Elixir 1.4.0 version when the default implementation of GenServer handle_info is used _([GenServer] Log warn on default handle_info/2 implementation)_. I simply added some lines to remove this warning.

