### PR TITLE
Remove unused module attributes

### DIFF
--- a/lib/espec/assertions/refute_receive.ex
+++ b/lib/espec/assertions/refute_receive.ex
@@ -6,8 +6,6 @@ defmodule ESpec.Assertions.RefuteReceive do
   """
   use ESpec.Assertions.Interface
 
-  @join_sym "\n\t"
-
   defp match(subject, pattern) do
     case subject do
       false -> {true, pattern}

--- a/lib/espec/expect_to.ex
+++ b/lib/espec/expect_to.ex
@@ -2,7 +2,6 @@ defmodule ESpec.ExpectTo do
   @moduledoc """
     Defines `to` and `to_not` functions which call specific 'assertion'
   """
-  @agent_name :espec_expect_to_agent
 
   @doc "Calls specific asserion."
   def to({module, data}, {__MODULE__, subject}) do

--- a/lib/espec/output/doc.ex
+++ b/lib/espec/output/doc.ex
@@ -6,7 +6,6 @@ defmodule ESpec.Output.Doc do
   @red IO.ANSI.red
   @cyan IO.ANSI.cyan
   @yellow IO.ANSI.yellow
-  @blue IO.ANSI.blue
   @reset IO.ANSI.reset
 
   @status_colors [success: @green, failure: @red, pending: @yellow]


### PR DESCRIPTION
Elixir 1.4 introduced some new warnings - including the one with unused module attributes.

This PR removes module attributes which caused warnings.

Also, I haven't touched few of those, as they're used by `credo`:
```
warning: module attribute @lint was set but never used
  lib/espec/doc_example.ex:214

warning: module attribute @lint was set but never used
  lib/espec/doc_test.ex:49
```
