### PR TITLE
Remove usages of deprecated Set module

### DIFF
--- a/spec/assertions/change_spec.exs
+++ b/spec/assertions/change_spec.exs
@@ -1,8 +1,8 @@
 defmodule ChangeSpec do
   use ESpec
 
-  def add(value), do: Agent.update(:some_spec_agent, &(Set.put(&1, value)))
-  def count, do: length(Agent.get(:some_spec_agent, &(&1)) |> Set.to_list)
+  def add(value), do: Agent.update(:some_spec_agent, &(MapSet.put(&1, value)))
+  def count, do: length(Agent.get(:some_spec_agent, &(&1)) |> MapSet.to_list)
 
   before do: Agent.start_link(fn -> MapSet.new end, name: :some_spec_agent)
   finally do: Agent.stop(:some_spec_agent)

--- a/test/assertions/change_test.exs
+++ b/test/assertions/change_test.exs
@@ -4,8 +4,8 @@ defmodule ChangeTest do
   defmodule SomeSpec do
     use ESpec
 
-    def add(value), do: Agent.update(:some_spec_agent, &(Set.put(&1, value)))
-    def count, do: length(Agent.get(:some_spec_agent, &(&1)) |> Set.to_list)
+    def add(value), do: Agent.update(:some_spec_agent, &(MapSet.put(&1, value)))
+    def count, do: length(Agent.get(:some_spec_agent, &(&1)) |> MapSet.to_list)
 
     before do: Agent.start_link(fn -> MapSet.new end, name: :some_spec_agent)
     finally do: Agent.stop(:some_spec_agent)


### PR DESCRIPTION
Elixir 1.4 introduced some new warnings, which were being triggered in `espec`.

This PR fixes the following warnings:

```
warning: Set.put/2 is deprecated, use the MapSet module for working with sets
  spec/assertions/change_spec.exs:4

warning: Set.to_list/1 is deprecated, use the MapSet module for working with sets
  spec/assertions/change_spec.exs:5

warning: Set.put/2 is deprecated, use the MapSet module for working with sets
  test/assertions/change_test.exs:7

warning: Set.to_list/1 is deprecated, use the MapSet module for working with sets
  test/assertions/change_test.exs:8
```