### PR TITLE
running suite by line runs the test the line is in

### DIFF
--- a/lib/espec/suite_runner.ex
+++ b/lib/espec/suite_runner.ex
@@ -114,12 +114,10 @@ defmodule ESpec.SuiteRunner do
 
   defp get_closest(arr, value) do
     arr = Enum.sort(arr)
-    diff = abs(value - hd(arr))
-    {_d, el} = Enum.reduce(arr, {diff, hd(arr)}, fn(el, {d, e}) ->
-      diff = abs(value - el)
-      if diff < d, do: {diff, el}, else: {d, e}
-    end)
-    el
+    line = arr
+      |> Enum.reverse
+      |> Enum.find(fn(l) -> l <= value end)
+    if line, do: line, else: hd(arr)
   end
 
   defp opts_for_file(file, opts_list) do


### PR DESCRIPTION
Current implementation of get_closest when running specs with line parameter yields unexpected results.

if I have
![image](https://cloud.githubusercontent.com/assets/203349/22467589/85decb30-e7c5-11e6-90c0-dbed1ce4a4dd.png)

and try to run the spec with line `:8` it will actually run the spec on line 10, which is highly unintuitive. I would expect it to run the spec in which the line is in.

In order to do this, I propose this simple heuristic: Always run the previous spec. If there is none, run the first one

What do you think?