### PR TITLE
Diff Structures for complex eq errors

### DIFF
--- a/lib/espec/assertions/eq.ex
+++ b/lib/espec/assertions/eq.ex
@@ -6,6 +6,8 @@ defmodule ESpec.Assertions.Eq do
   """
   use ESpec.Assertions.Interface
 
+  alias ESpec.StructDiff
+
   defp match(subject, value) do
     result = subject == value
     {result, result}
@@ -17,8 +19,17 @@ defmodule ESpec.Assertions.Eq do
   end
 
   defp error_message(subject, data, _result, positive) do
-    to = if positive, do: "to", else: "not to"
-    but = if positive, do: "doesn't", else: "does"
-    "Expected `#{inspect subject}` #{to} equals (==) `#{inspect data}`, but it #{but}."
+    expected = if positive, do: "Expected", else: "Didn't expect"
+    but = if positive do
+      StructDiff.diff(data, subject)
+      |> StructDiff.format_lines
+      |> format_diff
+    else
+      "got it"
+    end
+    "#{expected} (==) `#{inspect data}`, but #{but}"
   end
+
+  defp format_diff([line|[]]), do: line
+  defp format_diff(lines), do: ([""] ++ lines) |> Enum.join("\n")
 end

--- a/lib/espec/formatters/doc.ex
+++ b/lib/espec/formatters/doc.ex
@@ -41,7 +41,7 @@ defmodule ESpec.Formatters.Doc do
   defp format_failed(failed) do
     res = failed |> Enum.with_index
     |> Enum.map(fn({example, index}) ->
-      do_format_example(example, example.error.message, index)
+      do_format_example(example, example.error.message |> String.replace("\n", "\n\t  "), index)
     end)
     Enum.join(res, "\n")
   end

--- a/lib/espec/formatters/html.ex
+++ b/lib/espec/formatters/html.ex
@@ -88,7 +88,11 @@ defmodule ESpec.Formatters.Html do
     res = if String.length(ex.description) > 0 do
       ex.description
     else
-      if ex.status == :failure, do: ex.error.message, else: ex.result
+      if ex.status == :failure do
+        ex.error.message |> String.replace("\n", "<br>")
+      else
+        ex.result
+      end
     end
     res = "#{res} (#{ex.duration} ms)"
     String.replace(res, "\"", "'")

--- a/lib/espec/struct_diff.ex
+++ b/lib/espec/struct_diff.ex
@@ -1,0 +1,79 @@
+defmodule ESpec.StructDiff do
+  def format_diff(a, b, prefix\\''), do: diff(a,b) |> format(prefix)
+
+  def diff(a, b) when a == b, do: %{}
+  def diff(a, b) when is_list(a) and is_list(b) and length(a) == length(b) do
+    diff_enumerables(a, b) |> simplify(a,b)
+  end
+  def diff(a, b) when is_tuple(a) and is_tuple(b) do
+    al = a |> Tuple.to_list
+    bl = b |> Tuple.to_list
+    diff_enumerables(al, bl) |> simplify(a,b)
+  end
+  def diff(a, b) when is_map(a) and is_map(b) do
+    a_keys = a |> Map.keys |> MapSet.new
+    b_keys = b |> Map.keys |> MapSet.new
+
+    res = %{
+      :- => a_keys |> MapSet.difference(b_keys) |> Enum.to_list,
+      :+ => b_keys |> MapSet.difference(a_keys) |> Enum.to_list,
+    }
+    |> Enum.reject(fn {_, v} -> v == [] end)
+    |> Map.new
+
+    MapSet.intersection(a_keys, b_keys)
+    |> Enum.reduce(res, fn k, acc ->
+      acc |> Map.merge(diff(a[k], b[k]) |> wrap_ctx(k))
+    end)
+    |> simplify(a,b)
+  end
+  def diff(a, b) when a != b, do: %{:!= => {a, b}}
+
+  def format(diffmap, prefix\\"") when is_map(diffmap) do
+    [format_lines(diffmap)]
+    |> List.flatten
+    |> Enum.map(&"#{prefix}#{&1}\n")
+    |> Enum.join
+  end
+
+  def format_lines({:!=, {a, b}}), do: "#{inspect(a)} != #{inspect(b)}"
+  def format_lines({:+, l}),       do: "has extra: #{inspect l}"
+  def format_lines({:-, l}),       do: "missing: #{inspect l}"
+  def format_lines({ctx, diffmap}) when is_map(diffmap) do
+    ["at #{key(ctx)}:"]
+    ++ (format_lines(diffmap) |> indent)
+  end
+  def format_lines(diffmap) when map_size(diffmap) == 0, do: "Values completely match"
+  def format_lines(diffmap) do
+    diffmap |> Enum.flat_map(fn edit ->
+      [edit |> format_lines] |> List.flatten
+    end)
+  end
+
+  # Privates
+  defp indent([]), do: []
+  defp indent([line|lines]), do: [indent(line)] ++ indent(lines)
+  defp indent(line), do: "  #{line}"
+
+  defp diff_enumerables(a,b) do
+    Enum.zip(a,b)
+    |> Enum.with_index
+    |> Enum.reduce(%{}, fn {{a, b}, i}, acc ->
+      acc |> Map.merge(diff(a, b) |> wrap_ctx(i))
+    end)
+  end
+
+  defp wrap_ctx(edits, key) do
+    case edits |> Map.keys do
+      []                  -> %{}
+      [k] when is_list(k) -> %{[key]++k => edits[k]}
+      _                   -> %{[key] => edits}
+    end
+  end
+
+  defp simplify(edits, _, _) when map_size(edits) < 4, do: edits
+  defp simplify(_, a, b), do: %{:!= => {a, b}}
+
+  defp key([]), do: ''
+  defp key([k|t]), do: "[#{inspect k}]#{key t}"
+end

--- a/spec/assertions/eq_spec.exs
+++ b/spec/assertions/eq_spec.exs
@@ -19,17 +19,33 @@ defmodule ESpec.Assertions.EqSpec do
         before do
           {:shared,
             expectation: fn -> expect(1 + 1).to eq(3.0) end,
-            message: "Expected `2` to equals (==) `3.0`, but it doesn't."}
+            message: "Expected (==) `3.0`, but got: `2`"}
         end
 
         it_behaves_like(CheckErrorSharedSpec)
       end
 
+      context "with complex `to`" do
+        before do
+          {:shared,
+            expectation: fn -> expect(%{a: 2, b: 3, c: 4}).to eq(%{a: 2, b: 4}) end,
+            message: "Expected (==) `%{a: 2, b: 4}`, but \nhas extra: `[:c]`\nat [:b]:\n  got: `3`"}
+        end
+
+        it_behaves_like(CheckErrorSharedSpec)
+      end
+
+      # context "with complex `to`" do
+      #   subject do: %{a: 2, b: 3, c: 4}
+
+      #   it do: should eq %{a: 2, b: 4}
+      # end
+
       context "with `not_to`" do
         before do
           {:shared,
             expectation: fn -> expect(1 + 1).to_not eq(2) end,
-            message: "Expected `2` not to equals (==) `2`, but it does."}
+            message: "Didn't expect (==) `2`, but got it"}
         end
 
         it_behaves_like(CheckErrorSharedSpec)
@@ -61,7 +77,7 @@ defmodule ESpec.Assertions.EqSpec do
         before do
           {:shared,
             expectation: fn -> expect(2 + 2).to be 5 end,
-            message: "Expected `4` to equals (==) `5`, but it doesn't."}
+            message: "Expected (==) `5`, but got: `4`"}
         end
 
         it_behaves_like(CheckErrorSharedSpec)
@@ -71,7 +87,7 @@ defmodule ESpec.Assertions.EqSpec do
         before do
           {:shared,
             expectation: fn -> expect(1 + 1 == 1).to_not be false end,
-            message: "Expected `false` not to equals (==) `false`, but it does."}
+            message: "Didn't expect (==) `false`, but got it"}
         end
 
         it_behaves_like(CheckErrorSharedSpec)

--- a/spec/struct_diff_spec.exs
+++ b/spec/struct_diff_spec.exs
@@ -1,0 +1,180 @@
+defmodule StructDiffSpec do
+  use ESpec
+
+  alias ESpec.StructDiff
+
+  describe "#diff" do
+    subject do: StructDiff.diff(a, b)
+
+    context "for lists" do
+      let :a, do: [:a, :b, :c, :d, :e]
+
+      context "with different element-count" do
+        let :b, do: [:a, :b, :c]
+
+        it do: should eq %{:!= => b}
+      end
+
+      context "with differing elements" do
+        let :b, do: [:a, :b, :b, :d, :e]
+
+        it do: should eq %{[2] => %{:!= => :b}}
+      end
+
+      context "with many edits" do
+        let :b, do: [:b, :a, :d, :c, :e]
+
+        it do: should eq %{:!= => b}
+      end
+    end
+
+    context "for maps" do
+      let :a, do: %{a: 1, b: 2, c: 3}
+
+      context "with additional keys" do
+        let :b, do: %{a: 1, b: 2, c: 3, d: 4}
+
+        it do: should eq %{:+ => [:d]}
+      end
+
+      context "with missing keys" do
+        let :b, do: %{a: 1, c: 3}
+
+        it do: should eq %{:- => [:b]}
+      end
+
+      context "with differing values" do
+        let :b, do: %{a: 1, b: 3, c: 3}
+
+        it do: should eq %{[:b] => %{:!= => 3}}
+      end
+
+      context "with lots of changes" do
+        let :b, do: %{a: 2, c: 2, d: 4}
+
+        it do: should eq %{:!= => b}
+      end
+
+      context "for nested diffs" do
+        let :a, do: %{a: 1, b: [1, 2, 3], c: 3}
+
+        context "with single change" do
+          let :b, do: %{a: 1, b: [1, 3, 3], c: 3}
+
+          it do: should eq %{[:b,1] => %{:!= => 3}}
+        end
+
+        context "with multiples change" do
+          let :b, do: %{a: 1, b: [2, 3, 3], c: 3}
+
+          it do: should eq %{
+            [:b] => %{
+              [0] => %{:!= => 2},
+              [1] => %{:!= => 3},
+            },
+          }
+        end
+      end
+    end
+
+    context "for complex example" do
+      let :a, do: %{
+        users: ["richmond", "kate", "stephen"],
+        counter: 5,
+        rooms: %{
+          alpha: %{free: 3},
+          beta: %{free: 2},
+        },
+      }
+      let :b, do: %{
+        users: ["richmond", "kate", "julie"],
+        counter: 2,
+        rooms: %{
+          alpha: %{free: 3},
+          beta: %{free: 5},
+        },
+      }
+
+      it do: should eq %{
+        [:users, 2]            => %{:!= => "julie"},
+        [:counter]             => %{:!= => 2},
+        [:rooms, :beta, :free] => %{:!= => 5},
+      }
+    end
+  end
+
+  describe "#format" do
+    subject do: StructDiff.format(diffmap, prefix)
+    let :prefix, do: ""
+
+    context "for noop" do
+      let :diffmap, do: %{}
+
+      it do: should eq "Values completely match\n"
+    end
+
+    context "for extra items" do
+      let :diffmap, do: %{:+ => [:a, :b]}
+
+      it do: should eq "has extra: `[:a, :b]`\n"
+    end
+
+    context "for missing items" do
+      let :diffmap, do: %{:- => [:a, :b]}
+
+      it do: should eq "missing: `[:a, :b]`\n"
+    end
+
+    context "for mismatch" do
+      let :diffmap, do: %{:!= => :b}
+
+      it do: should eq "got: `:b`\n"
+    end
+
+    context "for complex example" do
+      let :diffmap, do: %{
+        [:users, 2]            => %{:!= => "julie"},
+        [:counter]             => %{:!= => 2},
+        [:rooms, :beta, :free] => %{:!= => 5},
+      }
+      let :prefix, do: "## "
+
+      it do: should eq "## at [:counter]:
+##   got: `2`
+## at [:rooms][:beta][:free]:
+##   got: `5`
+## at [:users][2]:
+##   got: `\"julie\"`
+"
+    end
+  end
+
+  describe "#format_diff" do
+    subject do: StructDiff.format_diff(a, b, prefix)
+    let :prefix, do: "## "
+    let :a, do: %{
+      users: ["richmond", "kate", "stephen"],
+      counter: 5,
+      rooms: %{
+        alpha: %{free: 3},
+        beta: %{free: 2},
+      },
+    }
+    let :b, do: %{
+      users: ["richmond", "kate", "julie"],
+      counter: 2,
+      rooms: %{
+        alpha: %{free: 3},
+        beta: %{free: 5},
+      },
+    }
+
+    it do: should eq "## at [:counter]:
+##   got: `2`
+## at [:rooms][:beta][:free]:
+##   got: `5`
+## at [:users][2]:
+##   got: `\"julie\"`
+"
+  end
+end

--- a/test/docs/doc_test_test.exs
+++ b/test/docs/doc_test_test.exs
@@ -56,7 +56,7 @@ defmodule ESpec.Docs.DocTestTest do
     ex = ESpec.ExampleRunner.run(context[:ex3])
     assert ex.description =~ "Doctest for Elixir.ESpec.DocTestTest.Mod1.f/0"
     assert ex.status == :failure
-    assert ex.error.message == "Expected `4` to equals (==) `5`, but it doesn't."
+    assert ex.error.message == "Expected (==) `5`, but got: `4`"
   end
 
   test "ex4", context do

--- a/test/example_runner_test.exs
+++ b/test/example_runner_test.exs
@@ -44,7 +44,7 @@ defmodule ExampleRunnerTest do
   test "run failed example", context do
     example = ESpec.ExampleRunner.run(context[:ex3])
     assert example.status == :failure
-    assert example.error.message == "Expected `1` to equals (==) `2`, but it doesn't."
+    assert example.error.message == "Expected (==) `2`, but got: `1`"
   end
 
   test "run failed example with runtime error", context do

--- a/test/output/doc_test.exs
+++ b/test/output/doc_test.exs
@@ -30,7 +30,7 @@ defmodule Formatters.DocTest do
     output = ESpec.Formatters.Doc.format_example(context[:failed_example], %{})
     assert output == "\e[31mF\e[0m"
     output = ESpec.Formatters.Doc.format_example(context[:failed_example], %{details: true})
-    assert output == "Formatters.DocTest.SomeSpec\n  \e[31mExpected `1` to equals (==) `2`, but it doesn't.\e[0m\n"
+    assert output == "Formatters.DocTest.SomeSpec\n  \e[31mExpected (==) `2`, but got: `1`\e[0m\n"
   end
 
   test "format_example pending_example", context do
@@ -45,7 +45,7 @@ defmodule Formatters.DocTest do
     output = ESpec.Formatters.Doc.format_result(context[:examples], durations, %{})
     assert String.match?(output, ~r/Formatters\.DocTest\.SomeSpec/)
     assert String.match?(output, ~r/Temporarily skipped with: `xit`/)
-    assert String.match?(output, ~r/Expected `1` to equals/)
+    assert String.match?(output, ~r/Expected \(==\) `2`, but got: `1`/)
     assert String.match?(output, ~r/3 examples, 1 failures, 1 pending/)
   end
 end


### PR DESCRIPTION
When an eq-assertions fails for a deep structure, the differences can be hard to spot.

The proposed changes adds a rudimentary diff-spec, that identifies changes and tries to express them more concisely. Can certainly be improved, but it's a start