### PR TITLE
Allowed generated examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ It is NOT a wrapper around ExUnit but a completely new testing framework written
   * `before` and `finally` blocks (like RSpec `before` and `after`).
   * `let`, `let!` and `subject`.
   * Shared examples.
+  * Generated examples.
   * Async examples.
   * Mocks with Meck.
   * Doc specs.
@@ -36,6 +37,7 @@ It is NOT a wrapper around ExUnit but a completely new testing framework written
 - [`shared` data](#shared-data)
 - [`let` and `subject`](#let-and-subject)
 - [Shared examples](#shared-examples)
+- [Generated examples](#generated-examples)
 - [Async examples](#async-examples)
 - [Matchers](#matchers)
 - [`assert` and `refute`](#assert-and-refute)
@@ -421,6 +423,24 @@ defmodule LetOverridableSpec do
   it_behaves_like(SharedSpec, a: 1, c: 3, e: 5)
 end
 ```
+
+## Generated examples
+Examples can be generated from code "templates". This should help with making the code more DRY:
+```elixir
+defmodule GeneratedExamplesSpec do
+  use ESpec, async: true
+
+  subject(24)
+
+  Enum.map 2..4, fn(n) ->
+    it "is divisible by #{n}" do
+      expect(rem(subject(), unquote(n))).to be(0)
+    end
+  end
+end
+```
+
+Please mind the `unquote` call above - if you forget to `unquote` the `n` variable the compiler will show some warnings about it missing and eventually stop with an error: `undefined function n/0`.
 
 ## Async examples
 There is an `async: true` option you can set for the context or for the individual example:
@@ -887,7 +907,7 @@ ESpec, like ExUnit, uses very simple wrapper around OTP's cover. But you can ove
 Take a look to [coverex](https://github.com/alfert/coverex) as a perfect example.
 
 ## Formatters
-There are three formatters in ESpec: 
+There are three formatters in ESpec:
 - ESpec.Formatters.Doc
 - ESpec.Formatters.Json
 - ESpec.Formatters.Html

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ defmodule ExampleTagsSpec do
 end
 ```
 
-##Filters
+## Filters
 The are `--only`, `--exclude` and `--string` command line options.
 
 One can tag example or context and then use `--only` or `--exclude` option to run (or exclude) tests with specific tag.

--- a/spec/generated_examples_spec.exs
+++ b/spec/generated_examples_spec.exs
@@ -1,0 +1,19 @@
+defmodule GeneratedExamplesSpec do
+  use ESpec, async: true
+
+  subject 1..5
+
+  Enum.map 1..3, fn(n) ->
+    it do: is_expected().to have(unquote(n))
+  end
+
+  context "with description" do
+    subject(24)
+
+    Enum.map 2..4, fn(n) ->
+      it "is divisible by #{n}" do
+        expect(rem(subject(), unquote(n))).to be(0)
+      end
+    end
+  end
+end

--- a/spec/generated_examples_spec.exs
+++ b/spec/generated_examples_spec.exs
@@ -16,4 +16,27 @@ defmodule GeneratedExamplesSpec do
       end
     end
   end
+
+  context "using a module attribute instead of unquote()" do
+    subject(%{a: 1, b: 2, c: 3})
+
+    Enum.each [:a, :b, :c], fn(key) ->
+      @key key
+      it "it has key #{key}" do
+        is_expected().to have_key(@key)
+      end
+    end
+  end
+
+  context "with description and shared data" do
+    subject([:c])
+    before do: {:shared, list: [:a, :b]}
+
+    Enum.each [:a, :b, :c], fn(value) ->
+      @value value
+      it "it + shared has value #{@value}" do
+        expect(subject() ++ shared.list).to have(@value)
+      end
+    end
+  end
 end

--- a/test/generated_examples_test.exs
+++ b/test/generated_examples_test.exs
@@ -1,0 +1,34 @@
+defmodule GeneratedExamplesTest do
+  use ExUnit.Case, async: true
+
+  defmodule SomeSpec do
+    use ESpec
+
+    Enum.map 1..3, fn(idx) ->
+      it "fails, same name" do
+        expect(unquote(idx)) |> to(eq(0))
+      end
+
+      it "fails, different name #{idx}" do
+        expect(unquote(idx)) |> to(eq(-1))
+      end
+    end
+  end
+
+  setup_all do
+    ESpec.Runner.Queue.start(:input)
+    ESpec.Runner.Queue.start(:output)
+    :ok
+  end
+
+  test "runs all of them and they fail with the appropriate message" do
+    examples = ESpec.SuiteRunner.run(SomeSpec, %{}, false)
+
+    assert(Enum.map(examples, fn(e) -> e.error.message end) ==
+      Enum.map(3..1, fn(idx) ->
+        ["Expected (==) `-1`, but got: `#{idx}`",
+         "Expected (==) `0`, but got: `#{idx}`"]
+      end)
+      |> List.flatten)
+  end
+end


### PR DESCRIPTION
I added a new feature you might like (I felt a need for it when DRY-ing my tests).

Examples can be generated via loops:
```elixir
  subject 1..5

  Enum.map 1..3, fn(n) ->
    it do: is_expected().to have(unquote(n))
  end
```

And examples descriptions can contain interpolations:
```elixir
  subject(24)

  Enum.map 2..4, fn(n) ->
    it "is divisible by #{n}" do
      expect(rem(subject(), unquote(n))).to be(0)
    end
  end
```

I think the above is better than:
```elixir
  subject(24)

  it "is divisible by some numbers" do
    Enum.map 2..4, fn(n) ->
      expect(rem(subject(), n)).to be(0)
    end
  end
```
Better because one can see all the tests that fail at once rather than just the first. And the only change to the code inside the test is that ```unquote``` call (which should not affect the readability that much).