### PR TITLE
Added a 1.5 seconds time limit for doing the diff

### DIFF
--- a/lib/espec/diff.ex
+++ b/lib/espec/diff.ex
@@ -1,12 +1,21 @@
 defmodule ESpec.Diff do
   def diff(expected, actual) do
-    diff = ExUnit.Diff.script(actual, expected)
+    diff = edit_script(actual, expected)
     format_diff(diff, {actual, expected}, false)
   end
 
   def diff_with_aligned_eq(expected, actual) do
-    diff = ExUnit.Diff.script(actual, expected)
+    diff = edit_script(actual, expected)
     format_diff(diff, {actual, expected}, true)
+  end
+
+  # shamelessly copied from ex_unit/formatter
+  defp edit_script(left, right) do
+    task = Task.async(ExUnit.Diff, :script, [left, right])
+    case Task.yield(task, 1_500) || Task.shutdown(task, :brutal_kill) do
+      {:ok, script} -> script
+      nil -> nil
+    end
   end
 
   defp format_diff(diff, {actual, expected}, align_eq) do

--- a/test/output/doc_diff_test.exs
+++ b/test/output/doc_diff_test.exs
@@ -65,6 +65,19 @@ defmodule Formatters.DocDiffTest do
     assert String.contains?(output, "\n\t  \e[36mactual:\e[0m   1\n")
   end
 
+  test "failed eq with very long string" do
+    defmodule SomeSpecEqLongString do
+      use ESpec
+
+      it do: expect(String.duplicate("external", 1000)).to eq(String.duplicate("expected", 1000))
+    end
+
+    output = output(SomeSpecEqLongString.examples)
+
+    assert String.contains?(output, "\n\t  \e[36mexpected:\e[0m \"#{String.duplicate("expected", 1000)}\"\n")
+    assert String.contains?(output, "\n\t  \e[36mactual:\e[0m   \"#{String.duplicate("external", 1000)}\"\n")
+  end
+
   test "failed negative eq without diff" do
     defmodule SomeSpecNotEq do
       use ESpec


### PR DESCRIPTION
Same as in `ExUnit`, I added a time limit for formatting the actual diff (and the diff itself is ran in another process).

I should have done this from the beginning. Without this, when the diff arguments are long strings, I get a `GenServer` timeout when the `stop` function for the `Doc` formatter is called (as the formatter has not yet finished doing the diff).