### PR TITLE
Made the output formatters configurable (via config.formatters_timeout)

### DIFF
--- a/lib/espec/configuration.ex
+++ b/lib/espec/configuration.ex
@@ -22,7 +22,9 @@ defmodule ESpec.Configuration do
     test: "For test purpose",
     start_loading_time: "Starts loading files",
     finish_loading_time: "Finished loading",
-    finish_specs_time: "Finished specs"
+    finish_specs_time: "Finished specs",
+    formatters_timeout: "How long to wait for the formatters to " <>
+                   "finish formatting (defaults to the GenServer call timeout)"
   ]
 
   @doc """


### PR DESCRIPTION
The timeout for the formatters to do their job can be configured like this:
```elixir
ESpec.configure fn(config) ->
  config.formatters_timeout 30_000
end
```

Should only be needed when there are a lot of failed test cases with `eq`-like assertions on long collections or strings (and, of course, the Doc formatter is active).

A message will be displayed (with the above as a suggestion) when the `ESpec.Output` process `stop` call times out.
