### PR TITLE
Elixir 1.5 compatibility for ExUnit.CaptureServer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,11 @@ elixir:
   - 1.3.4
   - 1.4.0
   - 1.4.5
+  - 1.5.0
 otp_release:
   - 18.3
   - 19.2
+  - 20.0
 sudo: false
 script:
   - mix test

--- a/lib/espec.ex
+++ b/lib/espec.ex
@@ -46,6 +46,19 @@ defmodule ESpec do
     end
   end
 
+  defmacrop version_safe_start_capture_server do
+    case Version.match?(System.version, ">= 1.5.0") do
+      true ->
+        quote do
+          ExUnit.CaptureServer.start_link([])
+        end
+      _ ->
+        quote do
+          ExUnit.CaptureServer.start_link()
+        end
+    end
+  end
+
   defmacro __before_compile__(_env) do
     quote do
       def examples, do: Enum.reverse(@examples)
@@ -98,7 +111,7 @@ defmodule ESpec do
 
   defp start_capture_server do
     if Code.ensure_loaded?(ExUnit.CaptureServer) do
-      unless GenServer.whereis(ExUnit.CaptureServer), do: ExUnit.CaptureServer.start_link()
+      unless GenServer.whereis(ExUnit.CaptureServer), do: version_safe_start_capture_server()
     end
   end
 


### PR DESCRIPTION
As discussed in issue "compability with Elixir 1.5" i have added a version to check inside a macro so we can call ExUnit.CaptureServer.start_link with the proper arity.

I have tested it with Elixir 1.5.0 and 1.4.1 and `mix espec` worked fine. On `mix test` however there seems to be another issue regarding Elixir 1.5.0.