### PR TITLE
Added the stacktrace to the failed examples

### DIFF
--- a/lib/espec/assert.ex
+++ b/lib/espec/assert.ex
@@ -8,8 +8,8 @@ defmodule ESpec.Assert do
   alias ESpec.Assertions.Boolean.BeFalsy
 
   @doc "Calls be_truthy assertion"
-  def assert(value), do: ExpectTo.to({BeTruthy, []}, {ExpectTo, value})
+  def assert(value), do: ExpectTo.to({BeTruthy, []}, {ExpectTo, value, nil})
 
   @doc "Calls be_falsy assertion"
-  def refute(value), do: ExpectTo.to({BeFalsy, []}, {ExpectTo, value})
+  def refute(value), do: ExpectTo.to({BeFalsy, []}, {ExpectTo, value, nil})
 end

--- a/lib/espec/assert_receive.ex
+++ b/lib/espec/assert_receive.ex
@@ -49,10 +49,10 @@ defmodule ESpec.AssertReceive do
           after
             unquote(timeout) ->
               args = [unquote(binary), unquote(pins), ESpec.AssertReceive.__mailbox_messages__]
-              ExpectTo.to({AssertReceive, args}, {ExpectTo, {:error, :timeout}})
+              ExpectTo.to({AssertReceive, args}, {ExpectTo, {:error, :timeout}, ESpec.Expect.pruned_stacktrace()})
           end
       args = [unquote(binary), unquote(pins), ESpec.AssertReceive.__mailbox_messages__]
-      ExpectTo.to({AssertReceive, args}, {ExpectTo, result})
+      ExpectTo.to({AssertReceive, args}, {ExpectTo, result, ESpec.Expect.pruned_stacktrace()})
     end
   end
 

--- a/lib/espec/assertion_error.ex
+++ b/lib/espec/assertion_error.ex
@@ -4,5 +4,6 @@ defmodule ESpec.AssertionError do
   The exception is raised by `ESpec.Assertions.Interface.raise_error/4` when example fails.
   """
   defexception subject: nil, data: nil,
-                result: nil, asserion: nil, message: nil, extra: nil
+                result: nil, asserion: nil, message: nil, extra: nil,
+                stacktrace: nil
 end

--- a/lib/espec/assertions/contain_exactly.ex
+++ b/lib/espec/assertions/contain_exactly.ex
@@ -20,7 +20,7 @@ defmodule ESpec.Assertions.ContainExactly do
   defp sort_collection(collection), do: collection
 
   defp diff(subject, data) do
-    ESpec.Diff.diff_with_aligned_eq(
+    ESpec.Diff.diff(
       sort_collection(subject),
       sort_collection(data)
     )

--- a/lib/espec/assertions/interface.ex
+++ b/lib/espec/assertions/interface.ex
@@ -17,7 +17,16 @@ defmodule ESpec.Assertions.Interface do
         end
       end
 
-      defp raise_error(subject, data, result, positive) do
+      def assert(subject, data, positive, stacktrace) do
+        case match(subject, data) do
+          {false, result} when positive -> raise_error(subject, data, result, positive, stacktrace)
+          {true, result} when not positive -> raise_error(subject, data, result, positive, stacktrace)
+          {true, result} when positive -> success_message(subject, data, result, positive)
+          {false, result} when not positive -> success_message(subject, data, result, positive)
+        end
+      end
+
+      defp raise_error(subject, data, result, positive, stacktrace \\ nil) do
         e = error_message(subject, data, result, positive)
         {message, extra} =
           case e do
@@ -30,7 +39,8 @@ defmodule ESpec.Assertions.Interface do
                 result: result,
                 asserion: __MODULE__,
                 message: message,
-                extra:  extra
+                extra:  extra,
+                stacktrace: stacktrace
       end
     end
   end

--- a/lib/espec/expect.ex
+++ b/lib/espec/expect.ex
@@ -11,12 +11,37 @@ defmodule ESpec.Expect do
     quote do
       @doc "The same as `expect(subject)`"
       def is_expected do
-        {ESpec.ExpectTo, apply(__MODULE__, :subject, [])}
+        {ESpec.ExpectTo, apply(__MODULE__, :subject, []), pruned_stacktrace()}
       end
     end
   end
 
   @doc "Wrapper for `ESpec.ExpectTo`."
-  def expect(do: value), do: {ExpectTo, value}
-  def expect(value), do: {ExpectTo, value}
+  def expect(do: value), do: {ExpectTo, value, pruned_stacktrace()}
+  def expect(value), do: {ExpectTo, value, pruned_stacktrace()}
+
+  def pruned_stacktrace() do
+    {:current_stacktrace, trace} = Process.info(self(), :current_stacktrace)
+    prune_stacktrace(trace)
+  end
+
+  # stop at the example runner
+  defp prune_stacktrace([{ESpec.ExampleRunner, _, _, _} | _rest]), do: []
+
+  # ignore these
+  defp prune_stacktrace([{Process, :info, _, _} | rest]), do: prune_stacktrace(rest)
+  defp prune_stacktrace([{_, :is_expected, 0, _} | rest]), do: prune_stacktrace(rest)
+  defp prune_stacktrace([{_, :should, 1, _} | rest]), do: prune_stacktrace(rest)
+  defp prune_stacktrace([{_, :should_not, 1, _} | rest]), do: prune_stacktrace(rest)
+  defp prune_stacktrace([{ESpec.Should, :should, 2, _} | rest]), do: prune_stacktrace(rest)
+  defp prune_stacktrace([{ESpec.Should, :should_not, 2, _} | rest]), do: prune_stacktrace(rest)
+  defp prune_stacktrace([{ESpec.To, :to, 2, _} | rest]), do: prune_stacktrace(rest)
+  defp prune_stacktrace([{ESpec.To, :not_to, 2, _} | rest]), do: prune_stacktrace(rest)
+  defp prune_stacktrace([{ESpec.To, :to_not, 2, _} | rest]), do: prune_stacktrace(rest)
+  defp prune_stacktrace([{ESpec.Expect, :expect, _, _} | rest]), do: prune_stacktrace(rest)
+  defp prune_stacktrace([{ESpec.Expect, :pruned_stacktrace, 0, _} | rest]), do: prune_stacktrace(rest)
+  defp prune_stacktrace([{ESpec.Expect, :prune_stacktrace, 2, _} | rest]), do: prune_stacktrace(rest)
+
+  defp prune_stacktrace([h | t]), do: [h | prune_stacktrace(t)]
+  defp prune_stacktrace([]), do: []
 end

--- a/lib/espec/expect_to.ex
+++ b/lib/espec/expect_to.ex
@@ -4,15 +4,15 @@ defmodule ESpec.ExpectTo do
   """
 
   @doc "Calls specific asserion."
-  def to({module, data}, {__MODULE__, subject}) do
-    apply(module, :assert, [subject, data, true])
+  def to({module, data}, {__MODULE__, subject, stacktrace}) do
+    apply(module, :assert, [subject, data, true, stacktrace])
   end
 
   @doc "Just apply 'assert' with `positive = false`."
-  def to_not({module, data}, {__MODULE__, subject}) do
-    apply(module, :assert, [subject, data, false])
+  def to_not({module, data}, {__MODULE__, subject, stacktrace}) do
+    apply(module, :assert, [subject, data, false, stacktrace])
   end
 
   @doc "Alias fo `to_not`."
-  def not_to(rhs, {__MODULE__, subject}), do: to_not(rhs, {__MODULE__, subject})
+  def not_to(rhs, {__MODULE__, subject, stacktrace}), do: to_not(rhs, {__MODULE__, subject, stacktrace})
 end

--- a/lib/espec/formatters/doc.ex
+++ b/lib/espec/formatters/doc.ex
@@ -119,7 +119,7 @@ defmodule ESpec.Formatters.Doc do
   defp in_this_example?(example, {module, function, arity, [file: file, line: _line]}) do
     module == example.module && function == example.function &&
       arity == 1 &&
-      file == String.to_char_list(Path.relative_to_cwd(example.file))
+      file == String.to_charlist(Path.relative_to_cwd(example.file))
   end
 
   defp remove_example_if_first([], _example) do

--- a/lib/espec/refute_receive.ex
+++ b/lib/espec/refute_receive.ex
@@ -36,7 +36,7 @@ defmodule ESpec.RefuteReceive do
           unquote(timeout) -> false
         end
 
-      ExpectTo.to({RefuteReceive, unquote(binary)}, {ExpectTo, result})
+      ExpectTo.to({RefuteReceive, unquote(binary)}, {ExpectTo, result, nil})
     end
   end
 end

--- a/lib/espec/should.ex
+++ b/lib/espec/should.ex
@@ -4,17 +4,18 @@ defmodule ESpec.Should do
   """
 
   alias ESpec.ExpectTo
+  alias ESpec.Expect
 
   @doc false
   defmacro __using__(_arg) do
     quote do
       @doc "The same as `subject |> should term )`"
-      def should(term), do: ExpectTo.to(term, {ExpectTo, apply(__MODULE__, :subject, [])})
-      def should_not(term), do: ExpectTo.to_not(term, {ExpectTo, apply(__MODULE__, :subject, [])})
+      def should(term), do: ExpectTo.to(term, {ExpectTo, apply(__MODULE__, :subject, []), Expect.pruned_stacktrace()})
+      def should_not(term), do: ExpectTo.to_not(term, {ExpectTo, apply(__MODULE__, :subject, []), Expect.pruned_stacktrace()})
     end
   end
 
   @doc "Wrapper for `ESpec.ExpectTo`."
-  def should(subject, term), do: ExpectTo.to(term, {ExpectTo, subject})
-  def should_not(subject, term), do: ExpectTo.to_not(term, {ExpectTo, subject})
+  def should(subject, term), do: ExpectTo.to(term, {ExpectTo, subject, Expect.pruned_stacktrace()})
+  def should_not(subject, term), do: ExpectTo.to_not(term, {ExpectTo, subject, Expect.pruned_stacktrace()})
 end

--- a/lib/espec/to.ex
+++ b/lib/espec/to.ex
@@ -38,24 +38,32 @@ defmodule ESpec.To do
   end
 
   @doc "Special case for `is_expected` when `subject` present."
-  def to({ExpectTo, subject}, {module, data}), do: to(subject, {module, data})
+  def to({ExpectTo, subject, stacktrace}, {module, data}) do
+    ExpectTo.to({module, data}, {ExpectTo, subject, stacktrace})
+  end
 
   @doc "Wrapper for `ESpec.ExpectTo.to`."
   def to(subject, {module, data}) do
-    ExpectTo.to({module, data}, {ExpectTo, subject})
+    ExpectTo.to({module, data}, {ExpectTo, subject, ESpec.Expect.pruned_stacktrace()})
   end
 
   @doc "Special case for `is_expected` when `subject` present."
-  def to_not({ExpectTo, subject}, {module, data}), do: to_not(subject, {module, data})
+  def to_not({ExpectTo, subject, stacktrace}, {module, data}) do
+    ExpectTo.to_not({module, data}, {ExpectTo, subject, stacktrace})
+  end
 
   @doc "Wrapper for `ESpec.ExpectTo.to_not`."
   def to_not(subject, {module, data}) do
-    ExpectTo.to_not({module, data}, {ExpectTo, subject})
+    ExpectTo.to_not({module, data}, {ExpectTo, subject, ESpec.Expect.pruned_stacktrace()})
   end
 
   @doc "Special case for `is_expected` when `subject` present."
-  def not_to({ExpectTo, subject}, {module, data}), do: not_to(subject, {module, data})
+  def not_to({ExpectTo, subject, stacktrace}, {module, data}) do
+    to_not({ExpectTo, subject, stacktrace}, {module, data})
+  end
 
   @doc "Wrapper for `ESpec.ExpectTo.not_to`."
-  def not_to(subject, {module, data}), do: to_not(subject, {module, data})
+  def not_to(subject, {module, data}) do
+    to_not(subject, {module, data})
+  end
 end

--- a/spec/diff_spec.exs
+++ b/spec/diff_spec.exs
@@ -10,15 +10,4 @@ defmodule DiffSpec do
       expect(ESpec.Diff.diff(1, 1)).to eq({[eq: "1"], [eq: "1"]})
     end
   end
-
-  describe ".diff_with_aligned_eq" do
-    it "when diff is" do
-      expected = {[eq: "[", ins: "1", ins: ", ", ins: "2", eq: "]"], [eq: "[", del: "2", ins_whitespace: 3, eq: "]"]}
-      expect(ESpec.Diff.diff_with_aligned_eq([1,2], [2])).to eq(expected)
-    end
-
-    it "when no diff" do
-      expect(ESpec.Diff.diff_with_aligned_eq([1,2], [1,2])).to eq({[eq: "[1, 2]"], [eq: "[1, 2]"]})
-    end
-  end
 end

--- a/spec_formatters/diff_showcase_spec.exs
+++ b/spec_formatters/diff_showcase_spec.exs
@@ -51,4 +51,27 @@ defmodule DiffShowcaseSpec do
   it "shows end_with" do
     expect("very big party").to end_with("sleep")
   end
+
+  defp inside_function(x) do
+    Process.alive?(self()) # some code
+    expect(x).to be(3)
+    Process.alive?(self()) # some more code
+  end
+
+  defp inside_function_wrapper(2.09 = x) do
+    expect(x).to be(3)
+  end
+  defp inside_function_wrapper(x) do
+    Process.alive?(self()) # some code
+    inside_function(x)
+    Process.alive?(self()) # some more code
+  end
+
+  it "shows a stacktrace for a function" do
+    inside_function_wrapper(2.09)
+  end
+
+  it "shows a stacktrace for a function in a function" do
+    inside_function_wrapper(3.90)
+  end
 end

--- a/test/output/doc_diff_test.exs
+++ b/test/output/doc_diff_test.exs
@@ -22,7 +22,7 @@ defmodule Formatters.DocDiffTest do
     output = output(SomeSpecContainsExactly.examples)
 
     assert String.contains?(output, "\n\t  \e[36mexpected:\e[0m [1, \e[31m22\e[0m, 48]\n")
-    assert String.contains?(output, "\n\t  \e[36mactual:\e[0m   [1, \e[32m5\e[0m , 48]\n")
+    assert String.contains?(output, "\n\t  \e[36mactual:\e[0m   [1, \e[32m5\e[0m, 48]\n")
   end
 
   #

--- a/test/output/doc_stacktrace_test.exs
+++ b/test/output/doc_stacktrace_test.exs
@@ -1,0 +1,119 @@
+defmodule Formatters.DocStacktraceTest do
+  use ExUnit.Case, async: true
+
+  @durations {{1_436, 865_768, 500_000}, {1_436, 865_768, 500_100}, {1_436, 865_768, 500_200}}
+
+  defp output(examples) do
+    examples
+    |> ESpec.SuiteRunner.run_examples(true)
+    |> ESpec.Formatters.Doc.format_result(@durations, %{diff_enabled?: true})
+  end
+
+  defp assert_contains(output, string) do
+    assert String.contains?(output, String.trim(string))
+  end
+
+  defp module_name(module) do
+    String.replace_leading("#{module}", "Elixir.", "")
+  end
+
+  modules = [
+    {"expect().to syntax", ExampleSpecDot, "example_spec_dot"},
+    {"expect() |> to syntax", ExampleSpecPipe, "example_spec_pipe"},
+    {"should syntax", ExampleSpecShould, "example_spec_should"}
+  ]
+
+  for {desc, module, file} <- modules do
+    Code.require_file(Path.join(__DIR__, "#{file}.exs"))
+    test desc do
+      m = unquote(module)
+      name = module_name(m)
+      f =
+        __DIR__
+        |> Path.relative_to_cwd()
+        |> Path.join("#{unquote(file)}.exs")
+
+      output = output(m.examples)
+
+      start_line = 3
+      for line <- start_line..(start_line + 2) do
+        assert_contains(
+            output,
+            """
+            #{name}
+            \t\e[36m#{f}:#{line}\e[0m
+            \t\e[31mExpected
+            """
+          )
+      end
+      assert_contains(
+          output,
+          """
+          liner
+          \t\e[36m#{f}:#{start_line + 5}: (inside example)
+          \t#{f}:#{start_line + 3}: (example)\e[0m
+          \t\e[31mExpected
+          """
+        )
+
+      start_line = 14
+      for line <- start_line..(start_line + 2) do
+        assert_contains(
+            output,
+            """
+            #{name}
+            \t\e[36m#{f}:#{line}\e[0m
+            \t\e[31mExpected
+            """
+          )
+      end
+      assert_contains(
+          output,
+          """
+          subject
+          \t\e[36m#{f}:#{start_line + 5}: (inside example)
+          \t#{f}:#{start_line + 3}: (example)\e[0m
+          \t\e[31mExpected
+          """
+        )
+
+      start_line = 23
+      assert_contains(
+          output,
+          """
+          has 3 expects, the second fails
+          \t\e[36m#{f}:#{start_line + 2}: (inside example)
+          \t#{f}:#{start_line}: (example)\e[0m
+          \t\e[31mExpected
+          """
+        )
+
+      start_line = 29
+      function_first_line = 34
+      assert_contains(
+          output,
+          """
+          has a failing expect in a function
+          \t\e[36m#{f}:#{function_first_line}: Elixir.#{name}.test_function/2
+          \t#{f}:#{start_line}: (example)\e[0m
+          \t\e[31mExpected
+          """
+        )
+
+      start_line = 38
+      first_function_line = 44
+      assert_contains(
+          output,
+          """
+          has a failing expect in some nested function call
+          \t\e[36m#{f}:#{first_function_line + 18}: Elixir.#{name}.level4/1
+          \t#{f}:#{first_function_line + 12}: Elixir.#{name}.level3/1
+          \t#{f}:#{first_function_line + 6}: Elixir.#{name}.level2/1
+          \t#{f}:#{first_function_line}: Elixir.#{name}.level1/1
+          \t#{f}:#{start_line}: (example)\e[0m
+          \t\e[31mExpected
+          """
+        )
+    end
+  end
+end

--- a/test/output/example_spec_dot.exs
+++ b/test/output/example_spec_dot.exs
@@ -1,0 +1,65 @@
+defmodule ExampleSpecDot do
+  use ESpec
+  it do: expect(1).to eq(2)
+  it do: expect(1).not_to eq(1)
+  it do: expect(1).to_not eq(1)
+  it "is not a one liner" do
+    a = 10
+    expect(1).to eq(a)
+    # empty
+  end
+
+  subject(1)
+
+  it do: is_expected().to eq(2)
+  it do: is_expected().not_to eq(1)
+  it do: is_expected().to_not eq(1)
+  it "is not a one liner with subject" do
+    a = 10
+    is_expected().to eq(a)
+    # empty
+  end
+
+  it "has 3 expects, the second fails" do
+    expect(1).to_not eq(2)
+    expect(1).to eql("1")
+    expect(1).not_to eq(1)
+  end
+
+  it "has a failing expect in a function" do
+    test_function(nil, nil)
+  end
+
+  defp test_function(_, _) do
+    expect(1).to eq("1")
+    expect(1).not_to eq(1)
+  end
+
+  it "has a failing expect in some nested function call" do
+    level1(nil)
+  end
+
+  defp level1(x) do
+    a = 1 # some code
+    level2(x)
+    a # trying to prevent the compiler from optimizing this
+  end
+
+  defp level2(x) do
+    a = 2 # some code
+    level3(x)
+    a # trying to prevent the compiler from optimizing this
+  end
+
+  defp level3(x) do
+    a = 3 # some code
+    level4(x)
+    a # trying to prevent the compiler from optimizing this
+  end
+
+  defp level4(x) do
+    a = 4 # some code
+    expect(x).to(eq(""))
+    a # trying to prevent the compiler from optimizing this
+  end
+end

--- a/test/output/example_spec_pipe.exs
+++ b/test/output/example_spec_pipe.exs
@@ -1,0 +1,65 @@
+defmodule ExampleSpecPipe do
+  use ESpec
+  it do: expect(1) |> to(eq(2))
+  it do: expect(1) |> not_to(eq(1))
+  it do: expect(1) |> to_not(eq(1))
+  it "is not a one liner" do
+    a = 10
+    expect(1) |> to(eq(a))
+    # empty
+  end
+
+  subject(1)
+
+  it do: is_expected() |> to(eq(2))
+  it do: is_expected() |> not_to(eq(1))
+  it do: is_expected() |> to_not(eq(1))
+  it "is not a one liner with subject" do
+    a = 10
+    is_expected() |> to(eq(a))
+    # empty
+  end
+
+  it "has 3 expects, the second fails" do
+    expect(1) |> to_not(eq(2))
+    expect(1) |> to(eql("1"))
+    expect(1) |> not_to(eq(1))
+  end
+
+  it "has a failing expect in a function" do
+    test_function(nil, nil)
+  end
+
+  defp test_function(_, _) do
+    expect(1) |> to(eq("1"))
+    expect(1) |> not_to(eq(1))
+  end
+
+  it "has a failing expect in some nested function call" do
+    level1(nil)
+  end
+
+  defp level1(x) do
+    a = 1 # some code
+    level2(x)
+    a # trying to prevent the compiler from optimizing this
+  end
+
+  defp level2(x) do
+    a = 2 # some code
+    level3(x)
+    a # trying to prevent the compiler from optimizing this
+  end
+
+  defp level3(x) do
+    a = 3 # some code
+    level4(x)
+    a # trying to prevent the compiler from optimizing this
+  end
+
+  defp level4(x) do
+    a = 4 # some code
+    expect(x).to(eq(""))
+    a # trying to prevent the compiler from optimizing this
+  end
+end

--- a/test/output/example_spec_should.exs
+++ b/test/output/example_spec_should.exs
@@ -1,0 +1,65 @@
+defmodule ExampleSpecShould do
+  use ESpec
+  it do: 1 |> should(eq(2))
+  it do: 1 |> should_not(eq(1))
+  it do: 1 |> should_not(eq(1))
+  it "is not a one liner" do
+    a = 10
+    1 |> should(eq(a))
+    a
+  end
+
+  subject(1)
+
+  it do: should(eq(2))
+  it do: should_not(eq(1))
+  it do: should_not(eq(1))
+  it "is not a one liner with subject" do
+    a = 10
+    should(eq(a))
+    a
+  end
+
+  it "has 3 expects, the second fails" do
+    1 |> should_not(eq(2))
+    1 |> should(eql("1"))
+    1 |> should_not(eq(1))
+  end
+
+  it "has a failing expect in a function" do
+    test_function(nil, nil)
+  end
+
+  defp test_function(_, _) do
+    1 |> should(eq("1"))
+    1 |> should_not(eq(1))
+  end
+
+  it "has a failing expect in some nested function call" do
+    level1(nil)
+  end
+
+  defp level1(x) do
+    a = 1 # some code
+    level2(x)
+    a # trying to prevent the compiler from optimizing this
+  end
+
+  defp level2(x) do
+    a = 2 # some code
+    level3(x)
+    a # trying to prevent the compiler from optimizing this
+  end
+
+  defp level3(x) do
+    a = 3 # some code
+    level4(x)
+    a # trying to prevent the compiler from optimizing this
+  end
+
+  defp level4(x) do
+    a = 4 # some code
+    expect(x).to(eq(""))
+    a # trying to prevent the compiler from optimizing this
+  end
+end


### PR DESCRIPTION
Hi @antonmi,

I added the stacktrace to the failed examples. And made a change to the way the diff is displayed for the `contains_exactly` assertion (gave up aligned diff, wasn't useful most of the times and sometimes it looked quite bad).

Here is an example of how the stacktrace is displayed:
![example-stacktrace](https://user-images.githubusercontent.com/19272511/28824002-dc3c802a-76c8-11e7-8171-8fa05c7dede0.png)

Please have a look at the code and if you think it is useful merge it.

Thanks!