### PR TITLE
Re-enable passing of Mix options through

### DIFF
--- a/lib/mix/tasks/espec.ex
+++ b/lib/mix/tasks/espec.ex
@@ -100,12 +100,12 @@ defmodule Mix.Tasks.Espec do
              only: :string, exclude: :string, string: :string, seed: :integer]
 
   def run(args) do
-    {opts, files} = OptionParser.parse!(args, strict: @switches)
+    {opts, files, mix_opts} = OptionParser.parse(args, strict: @switches)
 
     check_env!()
     Mix.Task.run "loadpaths", args
 
-    if Keyword.get(opts, :compile, true), do: Mix.Task.run("compile", args)
+    if Keyword.get(mix_opts, :compile, true), do: Mix.Task.run("compile", args)
 
     project = Mix.Project.config
     cover   = Keyword.merge(@cover, project[:test_coverage] || [])


### PR DESCRIPTION
Relating to: https://github.com/antonmi/espec/issues/221

By taking out the `parse!` we don't raise when mix options are passed in, but by retaining the strict check, we filter out any non-espec options from `opts`

We can then safely check for `--(no)-compile` in mix_opts

However, for line 120 (`Mix.Task.run "app.start", args`) we don't want to do the same sort of check, as we should delegate the decision as to how much to "start" to Mix. This lets it do things like use the configuration for things like logging (e.g. config/test.exs) while not starting up the main application process

I also did not want to specifically whitelist Mix arguments in here, as that might get out of date with subsequent releases of Mix