### PR TITLE
Ensure that `let!` with a keyword list only evaluates once for each example

### DIFF
--- a/lib/espec/let/let.ex
+++ b/lib/espec/let/let.ex
@@ -73,9 +73,19 @@ defmodule ESpec.Let do
 
   @doc "Allows to define several 'lets' at once"
   defmacro let!(keyword) when is_list keyword do
+    before_block =
+      keyword
+      |> Keyword.keys()
+      |> Enum.map(fn key ->
+        quote do: unquote(key)()
+      end)
+
     quote do
       let unquote(keyword)
-      before unquote(keyword)
+
+      before do
+        unquote(before_block)
+      end
     end
   end
 

--- a/spec/let/let_spec.exs
+++ b/spec/let/let_spec.exs
@@ -32,6 +32,30 @@ defmodule LetSpec do
       end
     end
 
+    context "only runs once per example" do
+      defp get_value do
+        value = Application.get_env(:espec, :letbang_value_once, "initial call")
+
+        Application.put_env(:espec, :letbang_value_once, "subsequent calls")
+
+        value
+      end
+
+      finally do: Application.delete_env(:espec, :letbang_value_once)
+
+      context "as `let! :value, do: get_value()`" do
+        let! :value, do: get_value()
+
+        it do: expect value() |> to(eq "initial call")
+      end
+
+      context "as `let! value: get_value()`" do
+        let! value: get_value()
+
+        it do: expect value() |> to(eq "initial call")
+      end
+    end
+
     context "when overridden, is used by before" do
       let! :test, do: "initial"
 

--- a/spec/let/let_spec.exs
+++ b/spec/let/let_spec.exs
@@ -32,7 +32,7 @@ defmodule LetSpec do
       end
     end
 
-    context "only runs once per example" do
+    context "only runs once per example", async: false do
       defp get_value do
         value = Application.get_env(:espec, :letbang_value_once, "initial call")
 


### PR DESCRIPTION
Instead of passing the keyword list directly to before, we now generate a list of calls to the generated functions.

# Example
## Before

Using `let! a: 1, b: 2` results in:

```elixir
let a: 1, b: 2
before a: 1, b: 2
```

## Now

Using `let! a: 1, b: 2` results in:

```elixir
let a: 1, b: 2

before do
  [a(), b()]
end
```

This ensures that the values of the keyword list really only get evaluated once, which is important when these values affect the global state.