### PR TITLE
DocTests: Improve exception message handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -858,8 +858,8 @@ ESpec has functionality similar to [`ExUnit.DocTest`](http://elixir-lang.org/doc
 Read more about docs syntax [here](http://elixir-lang.org/docs/stable/ex_unit/)
 The functionality is implemented by two modules:
 `ESpec.DocExample` parses module documentation and `ESpec.DocTest` creates 'spec' examples for it.
-`ESpec.DocExample` functions is just copy-paste of `ExUnit.Doctest` parsing functionality.
-`ESpec.DocTest` implement `doctest` macro which identical to `ExUnit` analogue.
+`ESpec.DocExample` functions are just copy-pasted from `ExUnit.Doctest` parsing functionality.
+`ESpec.DocTest` implements `doctest` macro which is identical to `ExUnit`.
 ```elixir
 defmodule DoctestSpec do
   use ESpec
@@ -1061,7 +1061,7 @@ There are community supported formatters:
   * 1.4.6
      - Fix doctests (allow "strings")
      - allow keywords in `let_ok` and `let_error`
-     - Fix `before` to ignore not enumerables  
+     - Fix `before` to ignore not enumerables
 
 ## Contributing
 ##### Contributions are welcome and appreciated!

--- a/lib/espec/doc_test.ex
+++ b/lib/espec/doc_test.ex
@@ -92,6 +92,7 @@ defmodule ESpec.DocTest do
               {str, new_binding}
             ex.type == :error ->
               {error_module, error_message} = ex.rhs
+              # Render the exception message as binary, to allow all characters
               error_message = <<0>> <> error_message
               lhs = ex.lhs
               str = """

--- a/lib/espec/doc_test.ex
+++ b/lib/espec/doc_test.ex
@@ -92,11 +92,13 @@ defmodule ESpec.DocTest do
               {str, new_binding}
             ex.type == :error ->
               {error_module, error_message} = ex.rhs
+              error_message = <<0>> <> error_message
               lhs = ex.lhs
               str = """
               def #{function}(shared) do
                 shared[:key]
-                expect(fn -> Code.eval_string(#{lhs}) end).to raise_exception(#{error_module}, ~s'#{error_message}')
+                <<0>> <> message = #{inspect error_message}
+                expect(fn -> Code.eval_string(#{lhs}) end).to raise_exception(#{error_module}, message)
               end
               """
               {str, binding}

--- a/spec/doc_test_spec.exs
+++ b/spec/doc_test_spec.exs
@@ -28,17 +28,43 @@ defmodule ESpec.DocTestTest.Mod1 do
     iex> dict = Enum.into([a: 10, b: 20], Map.new)
     iex> Map.get(dict, :a)
     10
-
-    iex> raise ArgumentError, message: ~S'Check for "string"'
-    ** (ArgumentError) Check for "string"
   """
   def f, do: :f
+end |> ESpec.TestHelpers.write_beam
+
+defmodule ESpec.DocTestTest.ExceptionInterpolation do
+  @moduledoc """
+    iex> raise ArgumentError, message: ~S'Check for "string"'
+    ** (ArgumentError) Check for "string"
+
+    iex> raise ArgumentError, message: "Check for 'string'"
+    ** (ArgumentError) Check for 'string'
+
+    iex> raise ArgumentError, message: "Check for |string|"
+    ** (ArgumentError) Check for |string|
+
+    iex> raise ArgumentError, message: "Check for /string/"
+    ** (ArgumentError) Check for /string/
+
+    iex> raise ArgumentError, message: "Check for (string)"
+    ** (ArgumentError) Check for (string)
+
+    iex> raise ArgumentError, message: "Check for [string]"
+    ** (ArgumentError) Check for [string]
+
+    iex> raise ArgumentError, message: "Check for {string}"
+    ** (ArgumentError) Check for {string}
+
+    iex> raise ArgumentError, message: "Check for <string>"
+    ** (ArgumentError) Check for <string>
+  """
 end |> ESpec.TestHelpers.write_beam
 
 defmodule DocTestSpec do
   use ESpec
 
   doctest ESpec.DocTestTest.Mod1
+  doctest ESpec.DocTestTest.ExceptionInterpolation
 
   it do: expect(ESpec.DocTestTest.Mod1.f).to eq(:f)
 end


### PR DESCRIPTION
This is an improvement on the first version using sigils with delimiters which again requires to escape `'` characters.

The changes in this PR will allow __all__ characters to appear in an exception message. This is achieved by rendering the exception message as a binary instead of a string.