### PR TITLE
Feature - Implement `match_pattern` assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,20 @@ Can be used with `:>`, `:<`, `:>=`, `:<=`, and etc.
 expect actual |> to(be operator, value)
 ```
 Passes if `apply(Kernel, operator, [actual, value]) == true`
+
+#### Patterns
+```elixir
+expect actual |> to(match_pattern {:ok, _}) # {:ok, _} = actual
+```
+It's not possible to call functions in the pattern and use the return value as
+pattern (`{:ok, function()}`), this obviously means no `let` functions. If you
+neeed to use the return value of a function, use a variable:
+
+```elixir
+value = function()
+
+expect actual |> to(match_pattern {:ok, ^value})
+```
 #### Booleans
 ```elixir
 expect actual |> to(be_true())

--- a/lib/espec/assertion_helpers.ex
+++ b/lib/espec/assertion_helpers.ex
@@ -17,6 +17,14 @@ defmodule ESpec.AssertionHelpers do
   def be_close_to(value, delta), do: {Assertions.BeCloseTo, [value, delta]}
   def match(value), do: {Assertions.Match, value}
 
+  defmacro match_pattern(pattern) do
+    pattern = Macro.escape(pattern)
+
+    quote do
+      {Assertions.MatchPattern, [unquote(pattern), __ENV__, binding()]}
+    end
+  end
+
   def be_true, do: {Assertions.Boolean.BeTrue, []}
   def be_false, do: {Assertions.Boolean.BeFalse, []}
   def be_truthy, do: {Assertions.Boolean.BeTruthy, []}

--- a/lib/espec/assertions/match_pattern.ex
+++ b/lib/espec/assertions/match_pattern.ex
@@ -25,14 +25,16 @@ defmodule ESpec.Assertions.MatchPattern do
     {result, result}
   end
 
-  defp success_message(subject, data, _result, positive) do
+  defp success_message(subject, [pattern, _env, _vars], _result, positive) do
+    data = Macro.to_string(pattern)
     to = if positive, do: "matches", else: "doesn't match"
-    "`#{inspect subject}` #{to} pattern (=) `#{inspect data}`."
+    "`#{inspect subject}` #{to} pattern (=) `#{data}`."
   end
 
-  defp error_message(subject, data, _result, positive) do
+  defp error_message(subject, [pattern, _env, _vars], _result, positive) do
+    data = Macro.to_string(pattern)
     to = if positive, do: "to", else: "not to"
     but = if positive, do: "doesn't", else: "does"
-    "Expected `#{inspect subject}` #{to} match pattern (=) `#{inspect data}`, but it #{but}."
+    "Expected `#{inspect subject}` #{to} match pattern (=) `#{data}`, but it #{but}."
   end
 end

--- a/spec/assertions/match_pattern_spec.exs
+++ b/spec/assertions/match_pattern_spec.exs
@@ -1,0 +1,41 @@
+defmodule ESpec.Assertions.MatchPatternSpec do
+  use ESpec, async: true
+
+  describe "ESpec.Assertions.MatchPattern" do
+    context "Success" do
+      context "Success" do
+        it "checks success with `to`" do
+          message = expect({:ok, 1}).to match_pattern({:ok, _})
+          expect(message) |> to(eq "`{:ok, 1}` matches pattern (=) `{:ok, _}`.")
+        end
+
+        it "checks success with `not_to`" do
+          message = expect({:ok, 1}).to_not match_pattern({:error, _})
+          expect(message) |> to(eq "`{:ok, 1}` doesn't match pattern (=) `{:error, _}`.")
+        end
+      end
+    end
+
+    context "Errors" do
+      context "with `to`" do
+        before do
+          {:shared,
+            expectation: fn -> expect({:ok, 1}).to match_pattern({:error, _}) end,
+            message: "Expected `{:ok, 1}` to match pattern (=) `{:error, _}`, but it doesn't."}
+        end
+
+        it_behaves_like(CheckErrorSharedSpec)
+      end
+
+      context "with `not_to`" do
+        before do
+          {:shared,
+            expectation: fn -> expect({:ok, 1}).to_not match_pattern({:ok, _}) end,
+            message: "Expected `{:ok, 1}` not to match pattern (=) `{:ok, _}`, but it does."}
+        end
+
+        it_behaves_like(CheckErrorSharedSpec)
+      end
+    end
+  end
+end

--- a/test/assertions/match_pattern_test.exs
+++ b/test/assertions/match_pattern_test.exs
@@ -1,0 +1,68 @@
+defmodule MatchPatternTest do
+  use ExUnit.Case, async: true
+
+  defmodule SomeSpec do
+    use ESpec
+
+    context "Success" do
+      ESpec.Context.describe "ESpec.Assertions.MatchPattern" do
+        it do: expect({:ok, 1}).to match_pattern({:ok, 1})
+        it do: expect({:ok, 1}).to match_pattern({:ok, _})
+
+        it do: expect({:ok, 1}).to_not match_pattern({:ok, 2})
+        it do: expect({:ok, 1}).to_not match_pattern({:error, _})
+
+        context "with pinned variables" do
+          it do
+            var = 1
+
+            expect({:ok, 1}).to match_pattern({:ok, ^var})
+          end
+
+          it do
+            pattern = {:ok, 1}
+
+            expect({:ok, 1}).to match_pattern(^pattern)
+          end
+        end
+      end
+    end
+
+    context "Errors" do
+      it do: expect({:ok, 1}).to_not match_pattern({:ok, 1})
+      it do: expect({:ok, 1}).to_not match_pattern({:ok, _})
+
+      it do: expect({:ok, 1}).to match_pattern({:ok, 2})
+      it do: expect({:ok, 1}).to match_pattern({:error, _})
+
+      context "with pinned variables" do
+        it do
+          var = 1
+
+          expect({:ok, 1}).to_not match_pattern({:ok, ^var})
+        end
+
+        it do
+          pattern = {:ok, 1}
+
+          expect({:ok, 1}).to_not match_pattern(^pattern)
+        end
+      end
+    end
+  end
+
+  setup_all do
+    examples = ESpec.SuiteRunner.run_examples(SomeSpec.examples, true)
+    {:ok,
+      success: Enum.slice(examples, 0, 6),
+      errors: Enum.slice(examples, 7, 13)}
+  end
+
+  test "Success", context do
+    Enum.each(context[:success], &(assert(&1.status == :success)))
+  end
+
+  test "Errors", context do
+    Enum.each(context[:errors], &(assert(&1.status == :failure)))
+  end
+end


### PR DESCRIPTION
As discussed in #232 this PR implements a new matcher called `MatchPattern` and can be used like this:

```elixir
expect actual |> to(match_pattern {:ok, _})
```

---

It is possible to use `^pinned_variables` but not to call functions in the match, which is consistent with elixirs match behaviour.

---

The README was updated with a new `Pattern` section.