### PR TITLE
DocTests: Fix issue with very long exception messages

### DIFF
--- a/lib/espec/doc_test.ex
+++ b/lib/espec/doc_test.ex
@@ -92,14 +92,11 @@ defmodule ESpec.DocTest do
               {str, new_binding}
             ex.type == :error ->
               {error_module, error_message} = ex.rhs
-              # Render the exception message as binary, to allow all characters
-              error_message = <<0>> <> error_message
               lhs = ex.lhs
               str = """
               def #{function}(shared) do
                 shared[:key]
-                <<0>> <> message = #{inspect error_message}
-                expect(fn -> Code.eval_string(#{lhs}) end).to raise_exception(#{error_module}, message)
+                expect(fn -> Code.eval_string(#{lhs}) end).to raise_exception(#{error_module}, #{inspect error_message})
               end
               """
               {str, binding}

--- a/spec/doc_test_spec.exs
+++ b/spec/doc_test_spec.exs
@@ -57,6 +57,9 @@ defmodule ESpec.DocTestTest.ExceptionInterpolation do
 
     iex> raise ArgumentError, message: "Check for <string>"
     ** (ArgumentError) Check for <string>
+
+    iex> raise ArgumentError, message: "Check for a very, very, very, very, very, very, very, very, very, very, very, very, very, very, very long string"
+    ** (ArgumentError) Check for a very, very, very, very, very, very, very, very, very, very, very, very, very, very, very long string
   """
 end |> ESpec.TestHelpers.write_beam
 


### PR DESCRIPTION
Yet another DocTest fix. I start to feel very silly.

While writing some exception doctests I've come to realise that elixir represents a long binary with a trailing `...` which in turn makes the compilation fail. Example: `<<0, 73, 110, 118, 97, 108, 105, 100, 32, 112, 97, 116, 104, 32, 99, 111, 109, 112, 111, 110, 101, 110, 116, 32, 39, 102, 111, 111, 39, 32, 102, 111, 114, 32, 118, 97, 108, 117, 101, 32, 39, 91, 102, 111, 111, 58, 32, 34, 98, 97, ...>>`.

While thinking about a solution I realised that I was going at this completely wrong. The solution proposed here is quite simple. It just uses `inspect` on the `error_message` which prints the strings with quotes and escapes everything.

So, this should be the definitive final version which works for anything.