### PR TITLE
Assertion - MatchPattern: Improve map handling and function usage error message

### DIFF
--- a/lib/espec/assertions/match_pattern.ex
+++ b/lib/espec/assertions/match_pattern.ex
@@ -8,21 +8,10 @@ defmodule ESpec.Assertions.MatchPattern do
 
   defp match(subject, [pattern, env, vars]) do
     pattern = Macro.expand(pattern, env)
-    vars =
-      for {key, value} <- vars do
-        quote do: unquote(Macro.var(key, nil)) = unquote(Macro.escape(value))
-      end
-
     result_quote =
-      quote do
-        import unquote(env.module)
+      quote do: match?(unquote(pattern), unquote(Macro.escape(subject)))
 
-        unquote_splicing(vars)
-
-        match?(unquote(pattern), unquote(Macro.escape(subject)))
-      end
-
-    {result, _} = Code.eval_quoted(result_quote)
+    {result, _} = Code.eval_quoted(result_quote, vars, env)
 
     {result, result}
   end

--- a/lib/espec/assertions/match_pattern.ex
+++ b/lib/espec/assertions/match_pattern.ex
@@ -15,6 +15,8 @@ defmodule ESpec.Assertions.MatchPattern do
 
     result_quote =
       quote do
+        import unquote(env.module)
+
         unquote_splicing(vars)
 
         match?(unquote(pattern), unquote(Macro.escape(subject)))

--- a/lib/espec/assertions/match_pattern.ex
+++ b/lib/espec/assertions/match_pattern.ex
@@ -17,7 +17,7 @@ defmodule ESpec.Assertions.MatchPattern do
       quote do
         unquote_splicing(vars)
 
-        match?(unquote(pattern), unquote(subject))
+        match?(unquote(pattern), unquote(Macro.escape(subject)))
       end
 
     {result, _} = Code.eval_quoted(result_quote)

--- a/test/assertions/match_pattern_test.exs
+++ b/test/assertions/match_pattern_test.exs
@@ -52,6 +52,16 @@ defmodule MatchPatternTest do
           expect({:ok, 1}).to_not match_pattern(^pattern)
         end
       end
+
+      context "with let functions" do
+        let foo: "bar"
+
+        it do
+          bar = :baz
+
+          expect("bar") |> to(match_pattern foo())
+        end
+      end
     end
   end
 
@@ -59,7 +69,7 @@ defmodule MatchPatternTest do
     examples = ESpec.SuiteRunner.run_examples(SomeSpec.examples, true)
     {:ok,
       success: Enum.slice(examples, 0, 8),
-      errors: Enum.slice(examples, 9, 17)}
+      errors: Enum.slice(examples, 9, 18)}
   end
 
   test "Success", context do

--- a/test/assertions/match_pattern_test.exs
+++ b/test/assertions/match_pattern_test.exs
@@ -57,8 +57,6 @@ defmodule MatchPatternTest do
         let foo: "bar"
 
         it do
-          bar = :baz
-
           expect("bar") |> to(match_pattern foo())
         end
       end

--- a/test/assertions/match_pattern_test.exs
+++ b/test/assertions/match_pattern_test.exs
@@ -8,9 +8,11 @@ defmodule MatchPatternTest do
       ESpec.Context.describe "ESpec.Assertions.MatchPattern" do
         it do: expect({:ok, 1}).to match_pattern({:ok, 1})
         it do: expect({:ok, 1}).to match_pattern({:ok, _})
+        it do: expect( %{"foo" => :bar}).to match_pattern(%{"foo" => _bar})
 
         it do: expect({:ok, 1}).to_not match_pattern({:ok, 2})
         it do: expect({:ok, 1}).to_not match_pattern({:error, _})
+        it do: expect(%{}).to_not match_pattern(%{"foo" => _bar})
 
         context "with pinned variables" do
           it do
@@ -31,9 +33,11 @@ defmodule MatchPatternTest do
     context "Errors" do
       it do: expect({:ok, 1}).to_not match_pattern({:ok, 1})
       it do: expect({:ok, 1}).to_not match_pattern({:ok, _})
+      it do: expect(%{"foo" => :bar}).to_not match_pattern(%{"foo" => _bar})
 
       it do: expect({:ok, 1}).to match_pattern({:ok, 2})
       it do: expect({:ok, 1}).to match_pattern({:error, _})
+      it do: expect(%{}).to match_pattern(%{"foo" => _bar})
 
       context "with pinned variables" do
         it do
@@ -54,8 +58,8 @@ defmodule MatchPatternTest do
   setup_all do
     examples = ESpec.SuiteRunner.run_examples(SomeSpec.examples, true)
     {:ok,
-      success: Enum.slice(examples, 0, 6),
-      errors: Enum.slice(examples, 7, 13)}
+      success: Enum.slice(examples, 0, 8),
+      errors: Enum.slice(examples, 9, 17)}
   end
 
   test "Success", context do


### PR DESCRIPTION
This PR improves the added `MatchPattern` assertion by ensuring that all subjects work fine with the assertion. Some values can not be represented in an quote and need to be *escaped* (using `Macro.escape/1`).

The subject now always get's escaped which allows all kind of values in the matcher.

---

Furthermore this PR greatly simplifies the actual match generation by making use of the 2nd and 3rd parameter of the `Code.eval_quoted`. Which allow to define bindings and all environment specific values.

This in turn improves the error message when using functions in a match. Before this the error would've complained that the function is not available, especially if the function was defined with a `let`. Now the compiler actually complains about a function used in a match.