### PR TITLE
Improve the error message when an unexpected exception is raised

### DIFF
--- a/lib/espec/assertions/raise_exception.ex
+++ b/lib/espec/assertions/raise_exception.ex
@@ -72,7 +72,10 @@ defmodule ESpec.Assertions.RaiseException do
 
   defp error_message(subject, [module], err_module, positive) do
     if positive do
-      "Expected #{inspect subject} to raise the `#{module}` exception, but nothing was raised."
+      case err_module do
+        {false, nil} -> "Expected #{inspect subject} to raise the `#{module}` exception, but nothing was raised."
+        err_module -> "Expected #{inspect subject} to raise the `#{module}` exception, but `#{err_module}` was raised instead."
+      end
     else
       "Expected #{inspect subject} not to raise the `#{module}` exception, but the `#{err_module}` exception was raised."
     end

--- a/spec/assertions/raise_exception_spec.exs
+++ b/spec/assertions/raise_exception_spec.exs
@@ -5,6 +5,7 @@ defmodule ESpec.Assertions.RaiseExceptionSpec do
     let :func1, do: fn -> raise(ArithmeticError) end
     let :func2, do: fn -> 1 + 1 end
     let :func3, do: fn -> List.first(:a) end
+    let :func4, do: fn -> raise(ArgumentError) end
 
     context "Success" do
       it "checks success with `to`" do
@@ -64,6 +65,15 @@ defmodule ESpec.Assertions.RaiseExceptionSpec do
         rescue
           error in [ESpec.AssertionError] ->
             expect(error.message) |> to(end_with "to raise the `Elixir.ArithmeticError` exception, but nothing was raised.")
+        end
+      end
+
+      it "checks error with `to`" do
+        try do
+          expect(func4()).to raise_exception(ArithmeticError)
+        rescue
+          error in [ESpec.AssertionError] ->
+            expect(error.message) |> to(end_with "to raise the `Elixir.ArithmeticError` exception, but `Elixir.ArgumentError` was raised instead.")
         end
       end
 

--- a/spec/assertions/raise_exception_spec.exs
+++ b/spec/assertions/raise_exception_spec.exs
@@ -86,6 +86,15 @@ defmodule ESpec.Assertions.RaiseExceptionSpec do
         end
       end
 
+      it "checks error with `to`" do
+        try do
+          expect(func4()).to raise_exception(ArithmeticError, "bad argument in arithmetic expression")
+        rescue
+          error in [ESpec.AssertionError] ->
+            expect(error.message) |> to(end_with "to raise the `Elixir.ArithmeticError` exception with the message `bad argument in arithmetic expression`, but the `Elixir.ArgumentError` exception was raised with the message `argument error`.")
+        end
+      end
+
       it "checks error with `not_to`" do
         try do
           expect(func1()).not_to raise_exception()


### PR DESCRIPTION
When expecting an exception and an unexpected exception is raised, ESpec would incorrectly report that nothing had been raised. This improves the error message in the case of not expecting a specific exception message and creates a spec for when a specific exception message is expected.