### PR TITLE
Assertions: Add match clauses to use `have` for Maps and Structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,9 +589,12 @@ expect string |> to(have_first value)   # String.first(string) == value
 ```
 #### Map
 ```elixir
-expect map |> to(have_key value)    # Map.has_key?(value)
-expect map |> to(have_value value)  # Enum.member?(Map.values(dict), value)
+expect map |> to(have foo: "bar")   # Map.get(map, :foo) == "bar"
+expect map |> to(have_key value)    # Map.has_key?(map, value)
+expect map |> to(have_value value)  # Enum.member?(Map.values(map), value)
 ```
+
+`have` also works for Structs.
 
 #### Type checking
 ``` elixir

--- a/lib/espec/assertions/enum_string/have.ex
+++ b/lib/espec/assertions/enum_string/have.ex
@@ -8,6 +8,15 @@ defmodule ESpec.Assertions.EnumString.Have do
   """
   use ESpec.Assertions.Interface
 
+  defp match(enum, [{_key, _value} = tuple]) do
+    match(enum, tuple)
+  end
+
+  defp match(%{} = map, {key, value}) do
+    result = (Map.get(map, key) == value)
+    {result, result}
+  end
+
   defp match(enum, val) when is_binary(enum) do
     result = String.contains?(enum, val)
     {result, result}

--- a/spec/assertions/map/have_spec.exs
+++ b/spec/assertions/map/have_spec.exs
@@ -1,0 +1,69 @@
+defmodule ESpec.Assertions.Map.HaveSpec do
+  use ESpec, async: true
+
+  defmodule TestStruct do
+    defstruct [:foo]
+  end
+
+  let map: %{foo: "bar"}
+  let struct: %TestStruct{foo: "bar"}
+
+  context "Success" do
+    it "checks success with `to` for map" do
+      message = expect(map()).to have({:foo, "bar"})
+      expect(message) |> to(eq "`%{foo: \"bar\"}` has `{:foo, \"bar\"}`.")
+    end
+
+    it "checks success with `to` for struct" do
+      message = expect(struct()).to have({:foo, "bar"})
+      expect(message) |> to(eq "`%ESpec.Assertions.Map.HaveSpec.TestStruct{foo: \"bar\"}` has `{:foo, \"bar\"}`.")
+    end
+
+    it "checks success with `to` for map with single element Keyword list" do
+      message = expect(map()).to have(foo: "bar")
+      expect(message) |> to(eq "`%{foo: \"bar\"}` has `[foo: \"bar\"]`.")
+    end
+
+    it "checks success with `to` for struct with single element Keyword list" do
+      message = expect(struct()).to have(foo: "bar")
+      expect(message) |> to(eq "`%ESpec.Assertions.Map.HaveSpec.TestStruct{foo: \"bar\"}` has `[foo: \"bar\"]`.")
+    end
+
+    it "checks success with `not_to`" do
+      message = expect(map()).to_not have(4)
+      expect(message) |> to(eq "`%{foo: \"bar\"}` doesn't have `4`.")
+    end
+  end
+
+  context "Error" do
+    context "with `to`" do
+      before do
+        {:shared,
+         expectation: fn -> expect(map()).to have(4) end,
+         message: "Expected `%{foo: \"bar\"}` to have `4`, but it has not."}
+      end
+
+      it_behaves_like(CheckErrorSharedSpec)
+    end
+
+    context "with `not_to`" do
+      before do
+        {:shared,
+         expectation: fn -> expect(map()).to_not have({:foo, "bar"}) end,
+         message: "Expected `%{foo: \"bar\"}` not to have `{:foo, \"bar\"}`, but it has."}
+      end
+
+      it_behaves_like(CheckErrorSharedSpec)
+    end
+
+    context "with `not_to`" do
+      before do
+        {:shared,
+         expectation: fn -> expect(struct()).to_not have({:foo, "bar"}) end,
+         message: "Expected `%ESpec.Assertions.Map.HaveSpec.TestStruct{foo: \"bar\"}` not to have `{:foo, \"bar\"}`, but it has."}
+      end
+
+      it_behaves_like(CheckErrorSharedSpec)
+    end
+  end
+end

--- a/test/assertions/map/have_test.exs
+++ b/test/assertions/map/have_test.exs
@@ -1,0 +1,50 @@
+defmodule Map.HaveTest do
+  use ExUnit.Case, async: true
+
+  defmodule SomeSpec do
+    use ESpec
+
+    defmodule TestStruct do
+      defstruct [:foo]
+    end
+
+    let map: %{foo: "bar"}
+    let struct: %TestStruct{foo: "bar"}
+
+    context "Success" do
+      it do: expect(map()).to have({:foo, "bar"})
+      it do: expect(map()).to have(foo: "bar")
+      it do: expect map() |> to(have foo: "bar")
+      it do: expect(map()).to_not have(4)
+
+      it do: expect(struct()).to have({:foo, "bar"})
+      it do: expect(struct()).to have(foo: "bar")
+      it do: expect(struct()).to_not have(4)
+    end
+
+    context "Error" do
+      it do: expect(map()).to_not have({:foo, "bar"})
+      it do: expect(map()).to_not have(foo: "bar")
+      it do: expect(map()).to have(4)
+
+      it do: expect(struct()).to_not have({:foo, "bar"})
+      it do: expect(struct()).to_not have(foo: "bar")
+      it do: expect(struct()).to have(4)
+    end
+  end
+
+  setup_all do
+    examples = ESpec.SuiteRunner.run_examples(SomeSpec.examples, true)
+    {:ok,
+     success: Enum.slice(examples, 0, 6),
+     errors: Enum.slice(examples, 7, 12)}
+  end
+
+  test "Success", context do
+    Enum.each(context[:success], &(assert(&1.status == :success)))
+  end
+
+  test "Errors", context do
+    Enum.each(context[:errors], &(assert(&1.status == :failure)))
+  end
+end


### PR DESCRIPTION
This PR adds `match` clauses to for Maps and Structs to allow for expectations like this:

```elixir
expect(%{}).to_not have(foo: "bar")
```

As you can see it also adds a special case to handle single element Keyword lists which makes testing for key value pairs a breeze.