### PR TITLE
Test - Config.finally: Add a test which raises and throws in finally

### DIFF
--- a/test/configuration/config_finally_error_test.exs
+++ b/test/configuration/config_finally_error_test.exs
@@ -1,0 +1,49 @@
+defmodule ConfigFinallyRaiseTest do
+  use ExUnit.Case, async: true
+
+  defmodule SomeSpec do
+    use ESpec
+    it do: "some test"
+  end
+
+  setup_all do
+    ESpec.configure fn(c) ->
+      c.finally fn ->
+        raise "An exception"
+      end
+    end
+
+    {:ok, ex1: Enum.at(SomeSpec.examples, 0)}
+  end
+
+  test "run ex1", context do
+    example = ESpec.ExampleRunner.run(context[:ex1])
+    assert example.status == :failure
+    assert String.match?(example.error.message, ~r/\(RuntimeError\) An exception/)
+  end
+end
+
+defmodule ConfigFinallyThrowTest do
+  use ExUnit.Case, async: true
+
+  defmodule SomeSpec do
+    use ESpec
+    it do: "some test"
+  end
+
+  setup_all do
+    ESpec.configure fn(c) ->
+      c.finally fn ->
+        throw :some_term
+      end
+    end
+
+    {:ok, ex2: Enum.at(SomeSpec.examples, 0)}
+  end
+
+  test "run ex2", context do
+    example = ESpec.ExampleRunner.run(context[:ex2])
+    assert example.status == :failure
+    assert String.match?(example.error.message, ~r/throw :some_term/)
+  end
+end


### PR DESCRIPTION
When raising or throwing something in config.finally the test succeeds and swallows the error silently which can lead to an undefined state and results in subsequent test failures if the config.finally block does some critical cleanup.

This PR adds two tests which currently fail due to this behaviour. It can be used to start working on a solution.