### PR TITLE
Mix formatter configuration

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,66 @@
+locals_without_parens = [
+  ## Test setup
+  before: 1,
+  finally: 1,
+  subject: :*,
+  subject!: :*,
+  let: :*,
+  let!: :*,
+  let_error: :*,
+  let_error!: :*,
+  let_ok: :*,
+  let_ok!: :*,
+  let_overridable: 1,
+
+  ## Examples
+  it_behaves_like: :*,
+  it: :*,
+
+  ## Assertions / Matchers
+  assert: 1,
+  refute: 1,
+  assert_receive: 3,
+  assert_received: 2,
+  refute_receive: 3,
+  refute_received: 2,
+  eq: 1,
+  eql: 1,
+
+  ### be_*
+  be: :*,
+  be_function: :*,
+  be_between: 2,
+  be_struct: 1,
+
+  ### have_*
+  have: 1,
+  have_key: 1,
+  have_value: 1,
+  have_count: 1,
+  have_first: 1,
+  have_last: 1,
+
+  ### match_*
+  match_pattern: 1,
+  match_list: 1,
+
+  # String matchers
+  start_with: 1,
+  end_with: 1,
+
+  ### Error matchers
+  raise_exception: :*,
+
+  ## Mocking / Stubbing
+  allow: 1,
+  accept: 2
+]
+
+[
+  inputs: [
+    "{mix,.formatter}.exs",
+    "{config,lib,spec,spec_formatter,test}/**/*.{ex,exs}"
+  ],
+  locals_without_parens: locals_without_parens,
+  export: [locals_without_parens: locals_without_parens]
+]


### PR DESCRIPTION
As discussed in #252 

The `locals_without_parens` list is probably not 100% complete, but I formatted the ESpec codebase locally and it looks like a good starting point that we can expand iteratively.

Did not format the codebase in this PR because it significantly bloats the diff.
To format, you can just run `mix format` on `v1.6.0-rc.0` or `master` Elixir.

`expect(...).to` and `should` syntax looks different, not sure if it's feasible to make it look the exact as it currently does with the formatter applied.

As usual, feel free to apply any changes you see fit @antonmi 

Best,
Jan