### PR TITLE
Feature: Add a diff for the `have` spec when it looks for a key-value tuple

### DIFF
--- a/lib/espec/assertions/enum_string/have.ex
+++ b/lib/espec/assertions/enum_string/have.ex
@@ -17,24 +17,88 @@ defmodule ESpec.Assertions.EnumString.Have do
     {result, result}
   end
 
-  defp match(enum, val) when is_binary(enum) do
-    result = String.contains?(enum, val)
+  defp match(enum, value) when is_binary(enum) do
+    result = String.contains?(enum, value)
     {result, result}
   end
 
-  defp match(enum, val) do
-    result = Enum.member?(enum, val)
+  defp match(enum, value) do
+    result = Enum.member?(enum, value)
     {result, result}
   end
 
-  defp success_message(enum, val, _result, positive) do
-    to = if positive, do: "has", else: "doesn't have"
-    "`#{inspect(enum)}` #{to} `#{inspect(val)}`."
+  defp success_message(enum, value, _result, positive) do
+    to_have = if positive, do: "has", else: "doesn't have"
+    value = build_success_value_string(value)
+
+    "`#{inspect(enum)}` #{to_have} #{value}."
   end
 
-  defp error_message(enum, val, result, positive) do
-    to = if positive, do: "to", else: "not to"
-    has = if result, do: "has", else: "has not"
-    "Expected `#{inspect(enum)}` #{to} have `#{inspect(val)}`, but it #{has}."
+  defp build_success_value_string([{_, _} = tuple]) do
+    build_success_value_string(tuple)
   end
+
+  defp build_success_value_string({key, value}) do
+    "`#{inspect(value)}` for key `#{inspect(key)}`"
+  end
+
+  defp build_success_value_string(value) do
+    "`#{inspect(value)}`"
+  end
+
+  defp error_message(enum, value, result, positive) do
+    build_error_message(enum, value, result, positive)
+  end
+
+  defp build_error_message(enum, [{_, _} = tuple], result, positive) do
+    build_error_message(enum, tuple, result, positive)
+  end
+
+  defp build_error_message(enum, {key, value}, result, positive) do
+    m =
+      "Expected `#{inspect(enum)}` #{to(positive)} have `#{inspect(value)}` for key `#{
+        inspect(key)
+      }`, but it #{has(result)}."
+
+    if positive do
+      actual = get_value(enum, key)
+
+      {m, %{diff_fn: fn -> ESpec.Diff.diff(actual, value) end}}
+    else
+      m
+    end
+  end
+
+  defp build_error_message(enum, value, result, positive) do
+    "Expected `#{inspect(enum)}` #{to(positive)} have `#{inspect(value)}`, but it #{has(result)}."
+  end
+
+  defp get_value(list, key) when is_list(list) do
+    if Keyword.keyword?(list) do
+      get_value_from_keyword(list, key)
+    else
+      nil
+    end
+  end
+
+  defp get_value(%{} = map, key) do
+    Map.get(map, key)
+  end
+
+  defp get_value(_, _) do
+    nil
+  end
+
+  defp get_value_from_keyword(list, key) do
+    list
+    |> Keyword.get_values(key)
+    |> Enum.map(&inspect/1)
+    |> Enum.join(" and ")
+  end
+
+  defp to(true), do: "to"
+  defp to(false), do: "not to"
+
+  defp has(true), do: "has"
+  defp has(false), do: "has not"
 end

--- a/spec/assertions/eq_spec.exs
+++ b/spec/assertions/eq_spec.exs
@@ -19,7 +19,8 @@ defmodule ESpec.Assertions.EqSpec do
         before do
           {:shared,
            expectation: fn -> expect(1 + 1).to(eq(3.0)) end,
-           message: "Expected `2` to equal (==) `3.0`, but it doesn't."}
+           message: "Expected `2` to equal (==) `3.0`, but it doesn't.",
+           extra: true}
         end
 
         it_behaves_like(CheckErrorSharedSpec)
@@ -30,7 +31,8 @@ defmodule ESpec.Assertions.EqSpec do
           {:shared,
            expectation: fn -> expect(%{a: 2, b: 3, c: 4}).to(eq(%{a: 2, b: 4})) end,
            message:
-             "Expected `%{a: 2, b: 3, c: 4}` to equal (==) `%{a: 2, b: 4}`, but it doesn't."}
+             "Expected `%{a: 2, b: 3, c: 4}` to equal (==) `%{a: 2, b: 4}`, but it doesn't.",
+           extra: true}
         end
 
         it_behaves_like(CheckErrorSharedSpec)
@@ -40,7 +42,8 @@ defmodule ESpec.Assertions.EqSpec do
         before do
           {:shared,
            expectation: fn -> expect(1 + 1).to_not(eq(2)) end,
-           message: "Expected `2` not to equal (==) `2`, but it does."}
+           message: "Expected `2` not to equal (==) `2`, but it does.",
+           extra: false}
         end
 
         it_behaves_like(CheckErrorSharedSpec)
@@ -72,7 +75,8 @@ defmodule ESpec.Assertions.EqSpec do
         before do
           {:shared,
            expectation: fn -> expect(2 + 2).to(be 5) end,
-           message: "Expected `4` to equal (==) `5`, but it doesn't."}
+           message: "Expected `4` to equal (==) `5`, but it doesn't.",
+           extra: true}
         end
 
         it_behaves_like(CheckErrorSharedSpec)
@@ -82,7 +86,8 @@ defmodule ESpec.Assertions.EqSpec do
         before do
           {:shared,
            expectation: fn -> expect(1 + 1 == 1).to_not(be false) end,
-           message: "Expected `false` not to equal (==) `false`, but it does."}
+           message: "Expected `false` not to equal (==) `false`, but it does.",
+           extra: false}
         end
 
         it_behaves_like(CheckErrorSharedSpec)

--- a/spec/assertions/map/have_spec.exs
+++ b/spec/assertions/map/have_spec.exs
@@ -11,26 +11,30 @@ defmodule ESpec.Assertions.Map.HaveSpec do
   context "Success" do
     it "checks success with `to` for map" do
       message = expect(map()).to(have({:foo, "bar"}))
-      expect(message) |> to(eq "`%{foo: \"bar\"}` has `{:foo, \"bar\"}`.")
+      expect(message) |> to(eq "`%{foo: \"bar\"}` has `\"bar\"` for key `:foo`.")
     end
 
     it "checks success with `to` for struct" do
       message = expect(struct()).to(have({:foo, "bar"}))
 
       expect(message)
-      |> to(eq "`%ESpec.Assertions.Map.HaveSpec.TestStruct{foo: \"bar\"}` has `{:foo, \"bar\"}`.")
+      |> to(
+        eq "`%ESpec.Assertions.Map.HaveSpec.TestStruct{foo: \"bar\"}` has `\"bar\"` for key `:foo`."
+      )
     end
 
     it "checks success with `to` for map with single element Keyword list" do
       message = expect(map()).to(have(foo: "bar"))
-      expect(message) |> to(eq "`%{foo: \"bar\"}` has `[foo: \"bar\"]`.")
+      expect(message) |> to(eq "`%{foo: \"bar\"}` has `\"bar\"` for key `:foo`.")
     end
 
     it "checks success with `to` for struct with single element Keyword list" do
       message = expect(struct()).to(have(foo: "bar"))
 
       expect(message)
-      |> to(eq "`%ESpec.Assertions.Map.HaveSpec.TestStruct{foo: \"bar\"}` has `[foo: \"bar\"]`.")
+      |> to(
+        eq "`%ESpec.Assertions.Map.HaveSpec.TestStruct{foo: \"bar\"}` has `\"bar\"` for key `:foo`."
+      )
     end
 
     it "checks success with `not_to`" do
@@ -44,7 +48,8 @@ defmodule ESpec.Assertions.Map.HaveSpec do
       before do
         {:shared,
          expectation: fn -> expect(map()).to(have(4)) end,
-         message: "Expected `%{foo: \"bar\"}` to have `4`, but it has not."}
+         message: "Expected `%{foo: \"bar\"}` to have `4`, but it has not.",
+         extra: false}
       end
 
       it_behaves_like(CheckErrorSharedSpec)
@@ -54,7 +59,8 @@ defmodule ESpec.Assertions.Map.HaveSpec do
       before do
         {:shared,
          expectation: fn -> expect(map()).to_not(have({:foo, "bar"})) end,
-         message: "Expected `%{foo: \"bar\"}` not to have `{:foo, \"bar\"}`, but it has."}
+         message: "Expected `%{foo: \"bar\"}` not to have `\"bar\"` for key `:foo`, but it has.",
+         exta: false}
       end
 
       it_behaves_like(CheckErrorSharedSpec)
@@ -65,7 +71,20 @@ defmodule ESpec.Assertions.Map.HaveSpec do
         {:shared,
          expectation: fn -> expect(struct()).to_not(have({:foo, "bar"})) end,
          message:
-           "Expected `%ESpec.Assertions.Map.HaveSpec.TestStruct{foo: \"bar\"}` not to have `{:foo, \"bar\"}`, but it has."}
+           "Expected `%ESpec.Assertions.Map.HaveSpec.TestStruct{foo: \"bar\"}` not to have `\"bar\"` for key `:foo`, but it has.",
+         extra: false}
+      end
+
+      it_behaves_like(CheckErrorSharedSpec)
+    end
+
+    context "with `to`" do
+      before do
+        {:shared,
+         expectation: fn -> expect(struct()).to(have({:foo, "baz"})) end,
+         message:
+           "Expected `%ESpec.Assertions.Map.HaveSpec.TestStruct{foo: \"bar\"}` to have `\"baz\"` for key `:foo`, but it has not.",
+         extra: true}
       end
 
       it_behaves_like(CheckErrorSharedSpec)

--- a/spec/shared/check_error_shared_spec.exs
+++ b/spec/shared/check_error_shared_spec.exs
@@ -5,7 +5,15 @@ defmodule CheckErrorSharedSpec do
     try do
       shared[:expectation].()
     rescue
-      error in [ESpec.AssertionError] -> expect(error.message) |> to(eq shared[:message])
+      error in [ESpec.AssertionError] ->
+        expect(error.message) |> to(eq shared[:message])
+
+        case shared[:extra] do
+          nil -> :ok
+          true -> expect(error.extra) |> to_not(be_nil())
+          false -> expect(error.extra) |> to(be_nil())
+          value -> expect(error.extra) |> to(eq value)
+        end
     end
   end
 end


### PR DESCRIPTION
As the title suggests. The error message for the `enum_string/have.ex` assertions has been extended.

It now actually talks about keys and values. It also returns a `diff_fn` for a positive match with the expected and actual data.

## Before

```
Expected `[a: 1]` to have `{:a, 2}`, but it has not.
```

## After

```
Expected `[a: 1]` to have `2` for key `:a`, but it has not.
  expected: 1
  actual:   2
```

---

In addition it extends the `CheckErrorSharedSpec` to allow checking for an `extra` in the raised error. This is used to test the inclusion of the diff in the `have` assertion and also for `eq` whose spec has been extended.