### PR TITLE
Start every test in a new process, watch for it's death

### DIFF
--- a/lib/espec.ex
+++ b/lib/espec.ex
@@ -84,7 +84,6 @@ defmodule ESpec do
 
   @doc "Runs the examples"
   def run do
-    ESpec.Runner.start()
     ESpec.Output.start()
     ESpec.Runner.run()
   end
@@ -95,6 +94,7 @@ defmodule ESpec do
     start_specs_agent()
     ESpec.Let.Impl.start_agent()
     ESpec.Mock.start_agent()
+    ESpec.Runner.start()
     start_capture_server()
   end
 

--- a/lib/espec/runner.ex
+++ b/lib/espec/runner.ex
@@ -13,6 +13,7 @@ defmodule ESpec.Runner do
   def start do
     Queue.start(:input)
     Queue.start(:output)
+    Task.Supervisor.start_link(name: ESpec.TaskSupervisor)
   end
 
   @doc "Runs all examples."
@@ -24,6 +25,7 @@ defmodule ESpec.Runner do
   def stop do
     Queue.stop(:input)
     Queue.stop(:output)
+    Supervisor.stop(ESpec.TaskSupervisor)
   end
 
   defp do_run(specs, opts) do


### PR DESCRIPTION
Fixes #283, where the whole suite might crash on a single test