### PR TITLE
Fix small typo in documentation for Assertions.Interface

### DIFF
--- a/lib/espec/assertions/interface.ex
+++ b/lib/espec/assertions/interface.ex
@@ -1,7 +1,7 @@
 defmodule ESpec.Assertions.Interface do
   @moduledoc """
   Defines the assertion interface.
-  There are 3 function should be defined in the 'assertion' module:
+  There are 3 functions that should be defined in the 'assertion' module:
   - `match/2`;
   - `success_message/4`;
   - `error_message/4`.


### PR DESCRIPTION
Just happened to notice this as I was going through the code.