### PR TITLE
Bugfix - Incorrect shared values in before

### DIFF
--- a/lib/espec/example.ex
+++ b/lib/espec/example.ex
@@ -5,6 +5,8 @@ defmodule ESpec.Example do
   Example structs %ESpec.Example are accumulated in @examples attribute
   """
 
+  @type t :: %__MODULE__{}
+
   @doc """
   Example struct.
   description - the description of example,
@@ -56,20 +58,25 @@ defmodule ESpec.Example do
   def extract_contexts(example), do: extract(example.context, ESpec.Context)
 
   @doc "Extracts example option."
+  @spec extract_option(t(), option :: atom()) :: nil | any()
   def extract_option(example, option) do
-    opts = extract_options(example)
-    opt = Enum.find(opts, fn {k, _v} -> k == option end)
-
-    if opt do
-      {^option, value} = opt
-      value
-    else
-      nil
-    end
+    example
+    |> extract_options()
+    |> Map.get(option)
   end
 
-  @doc "Extracts example options."
+  @doc "Extracts example options as they are currently valid for this example as map."
+  @spec extract_options(t()) :: %{required(atom()) => any()}
   def extract_options(example) do
+    example
+    |> extract_all_options()
+    |> Enum.uniq_by(fn {key, _} -> key end)
+    |> Map.new()
+  end
+
+  @doc "Extracts example options from most specific to least specific as Keyword list. Can include duplicates."
+  @spec extract_all_options(t()) :: Keyword.t()
+  def extract_all_options(example) do
     contexts = ESpec.Example.extract_contexts(example)
     List.flatten(example.opts ++ Enum.reverse(Enum.map(contexts, & &1.opts)))
   end

--- a/lib/espec/example_runner.ex
+++ b/lib/espec/example_runner.ex
@@ -43,6 +43,7 @@ defmodule ESpec.ExampleRunner do
   end
 
   defp check_example_task({:ok, example_result}, _, _), do: example_result
+
   defp check_example_task({:exit, reason}, example, start_time) do
     error = %AssertionError{message: "Process exited with reason: #{inspect(reason)}"}
     do_rescue(example, %{}, start_time, error, false)

--- a/lib/espec/example_runner.ex
+++ b/lib/espec/example_runner.ex
@@ -70,10 +70,7 @@ defmodule ESpec.ExampleRunner do
     end
   end
 
-  defp initial_shared(example) do
-    Example.extract_options(example)
-    |> Enum.into(%{})
-  end
+  defp initial_shared(example), do: Example.extract_options(example)
 
   defp before_example_actions(example) do
     {initial_shared(example), example}

--- a/spec/regression/incorrect_shared_values_in_before_spec.exs
+++ b/spec/regression/incorrect_shared_values_in_before_spec.exs
@@ -1,0 +1,13 @@
+defmodule Regression.IncorrectSharedValuesInBeforeSpec do
+  use ESpec, option: true
+
+  before do: send self(), {:option, shared[:option]}
+
+  it "option should be true" do
+    assert_receive {:option, true}
+  end
+
+  it "option should be false", option: false do
+    assert_receive {:option, false}
+  end
+end

--- a/spec/regression/incorrect_shared_values_in_before_spec.exs
+++ b/spec/regression/incorrect_shared_values_in_before_spec.exs
@@ -1,7 +1,7 @@
 defmodule Regression.IncorrectSharedValuesInBeforeSpec do
   use ESpec, option: true
 
-  before do: send self(), {:option, shared[:option]}
+  before do: send(self(), {:option, shared[:option]})
 
   it "option should be true" do
     assert_receive {:option, true}

--- a/test/examples/example_extract_option_test.exs
+++ b/test/examples/example_extract_option_test.exs
@@ -30,6 +30,19 @@ defmodule ExampleHasOptionTest do
      ex3: Enum.at(SomeSpec.examples(), 2)}
   end
 
+  test ".extract_options ex1 returns the expected, most specific options", context do
+    ex = context[:ex1]
+
+    assert ESpec.Example.extract_options(ex) == %{
+      a: true,
+      b: true,
+      c: true,
+      d: true,
+      e: true,
+      f: true
+    }
+  end
+
   test ".extract_option ex1, <option> returns the expected values", context do
     ex = context[:ex1]
 
@@ -42,12 +55,30 @@ defmodule ExampleHasOptionTest do
     assert ESpec.Example.extract_option(ex, :g) == nil
   end
 
+  test ".extract_options ex2 returns the expected, most specific options", context do
+    ex = context[:ex2]
+
+    assert ESpec.Example.extract_options(ex) == %{
+      a: false,
+      b: false
+    }
+  end
+
   test ".extract_option ex2, <option> returns the expected values", context do
     ex = context[:ex2]
 
     assert ESpec.Example.extract_option(ex, :a) == false
     assert ESpec.Example.extract_option(ex, :b) == false
     assert ESpec.Example.extract_option(ex, :c) == nil
+  end
+
+  test ".extract_options ex3 returns the expected, most specific options", context do
+    ex = context[:ex3]
+
+    assert ESpec.Example.extract_options(ex) == %{
+      a: true,
+      b: false
+    }
   end
 
   test ".extract_option ex3, <option> returns the expected values", context do

--- a/test/examples/example_extract_option_test.exs
+++ b/test/examples/example_extract_option_test.exs
@@ -34,13 +34,13 @@ defmodule ExampleHasOptionTest do
     ex = context[:ex1]
 
     assert ESpec.Example.extract_options(ex) == %{
-      a: true,
-      b: true,
-      c: true,
-      d: true,
-      e: true,
-      f: true
-    }
+             a: true,
+             b: true,
+             c: true,
+             d: true,
+             e: true,
+             f: true
+           }
   end
 
   test ".extract_option ex1, <option> returns the expected values", context do
@@ -59,9 +59,9 @@ defmodule ExampleHasOptionTest do
     ex = context[:ex2]
 
     assert ESpec.Example.extract_options(ex) == %{
-      a: false,
-      b: false
-    }
+             a: false,
+             b: false
+           }
   end
 
   test ".extract_option ex2, <option> returns the expected values", context do
@@ -76,9 +76,9 @@ defmodule ExampleHasOptionTest do
     ex = context[:ex3]
 
     assert ESpec.Example.extract_options(ex) == %{
-      a: true,
-      b: false
-    }
+             a: true,
+             b: false
+           }
   end
 
   test ".extract_option ex3, <option> returns the expected values", context do

--- a/test/examples/example_extract_option_test.exs
+++ b/test/examples/example_extract_option_test.exs
@@ -30,26 +30,29 @@ defmodule ExampleHasOptionTest do
      ex3: Enum.at(SomeSpec.examples(), 2)}
   end
 
-  test "ex1 options", context do
+  test ".extract_option ex1, <option> returns the expected values", context do
     ex = context[:ex1]
-    assert ESpec.Example.extract_option(ex, :a)
-    assert ESpec.Example.extract_option(ex, :b)
-    assert ESpec.Example.extract_option(ex, :c)
-    assert ESpec.Example.extract_option(ex, :d)
-    assert ESpec.Example.extract_option(ex, :e)
-    assert ESpec.Example.extract_option(ex, :f)
+
+    assert ESpec.Example.extract_option(ex, :a) == true
+    assert ESpec.Example.extract_option(ex, :b) == true
+    assert ESpec.Example.extract_option(ex, :c) == true
+    assert ESpec.Example.extract_option(ex, :d) == true
+    assert ESpec.Example.extract_option(ex, :e) == true
+    assert ESpec.Example.extract_option(ex, :f) == true
     assert ESpec.Example.extract_option(ex, :g) == nil
   end
 
-  test "ex2 options", context do
+  test ".extract_option ex2, <option> returns the expected values", context do
     ex = context[:ex2]
+
     assert ESpec.Example.extract_option(ex, :a) == false
     assert ESpec.Example.extract_option(ex, :b) == false
     assert ESpec.Example.extract_option(ex, :c) == nil
   end
 
-  test "ex3 options", context do
+  test ".extract_option ex3, <option> returns the expected values", context do
     ex = context[:ex3]
+
     assert ESpec.Example.extract_option(ex, :a) == true
     assert ESpec.Example.extract_option(ex, :b) == false
     assert ESpec.Example.extract_option(ex, :c) == nil


### PR DESCRIPTION
This PR fixes an issue with the tags passed into `before` blocks. The issue occurred when a tag was overwritten in a lower context and then the same tag accessed in the `before` clause.

See the below added and currently failing regression test:

```elixir
defmodule Regression.IncorrectSharedValuesInBeforeSpec do
  use ESpec, option: true

  before do: send self(), {:option, shared[:option]}

  it "option should be true" do
    assert_receive {:option, true}
  end

  it "option should be false", option: false do
    assert_receive {:option, false}
  end
end
```

# Cause

The cause for this issue was that `Example.extract_options/1` returned a Keyword list with all entries, sorted by most specific to least specific.

https://github.com/antonmi/espec/blob/541ca38e9b548cbcc5c23882ee4af97c21f17b3c/lib/espec/example.ex#L72-L75

This Keyword list was then transformed to a map in `ExampleRunner`:

https://github.com/antonmi/espec/blob/541ca38e9b548cbcc5c23882ee4af97c21f17b3c/lib/espec/example_runner.ex#L73-L76

This in turn iterated over the received Keyword list, putting the elements into a map. The ordering then lead to less specific values overriding more specific ones.

Long story short. A Keyword list looking like this:

```elixir
[
  a: 1, # Most specific a
  b: 2,
  a: 3  # Least specific a
]
```

Became this map:

```elixir
%{
  a: 3,
  b: 2
}
```

# Solution

This PR updates the `Example.extract_options/1` implementation to instead return a map with the currently valid options. It also updates `Example.extract_option/2` to make use of this map instead of iterating over the keyword list.

The previous implementation can now be accessed under `Example.extract_all_options/1`.