### PR TITLE
Add parenthesis to avoid ambiguous pipe in doctest

### DIFF
--- a/lib/espec/doc_test.ex
+++ b/lib/espec/doc_test.ex
@@ -129,7 +129,7 @@ defmodule ESpec.DocTest do
               str = """
               def #{function}(shared) do
                 shared[:key]
-                expect(#{inspect(lhs)}) |> to eq(#{inspect(rhs)})
+                expect(#{inspect(lhs)}) |> to(eq(#{inspect(rhs)}))
               end
               """
 


### PR DESCRIPTION
For a doctest that uses an `:inspect` a warning is issued for `elixir 1.8.2-otp-22`

```
warning: parentheses are required when piping into a function call. For example:

    foo 1 |> bar 2 |> baz 3

is ambiguous and should be written as

    foo(1) |> bar(2) |> baz(3)
```