### PR TITLE
Add missing type checking matcher to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,9 +588,17 @@ expect :espec |> to(be_atom)  #is_atom(:espec) == true
 ... be_binary()
 ... be_bitstring()
 ... be_boolean()
+... be_integer()
+... be_float()
+... be_number()
 ... ...
 ... ...
 ... be_tuple()
+... be_list()
+... be_map()
+... be_port()
+... be_pid()
+... be_reference()
 ... be_function()
 ... be_function arity
 ... be_struct()


### PR DESCRIPTION
I noticed that some type check matchers  are missing in README, so I added them.

I decided what to add based on the type spec file ,`be_type_spec.exs`.


https://github.com/antonmi/espec/blob/ba6a4cc8106814f9187e88cf96596a77d59ca539/spec/assertions/be_type_spec.exs 