### PR TITLE
Fix map.field notation warnings

### DIFF
--- a/lib/espec/suite_runner.ex
+++ b/lib/espec/suite_runner.ex
@@ -18,7 +18,7 @@ defmodule ESpec.SuiteRunner do
   end
 
   defp run_module_examples(module, opts, shuffle) do
-    examples_to_run = filter(module.examples, opts)
+    examples_to_run = filter(module.examples(), opts)
 
     if shuffle do
       run_examples(Enum.shuffle(examples_to_run))

--- a/lib/mix/tasks/espec.ex
+++ b/lib/mix/tasks/espec.ex
@@ -130,7 +130,7 @@ defmodule Mix.Tasks.Espec do
         cover[:tool].start(Mix.Project.compile_path(project), cover)
       end
 
-    Mix.shell().print_app
+    Mix.shell().print_app()
     Mix.Task.run("app.start", args)
 
     ensure_espec_loaded!()


### PR DESCRIPTION
This PR fixes the following warnings that seem to have been introduced in one of the newer versions of Elixir:

```
warning: using map.field notation (without parentheses) to invoke function Mix.Shell.IO.print_app() is deprecated, you must add parentheses instead: remote.function()
  (espec 1.9.2) lib/mix/tasks/espec.ex:133: Mix.Tasks.Espec.run/1
  (mix 1.17.3) lib/mix/task.ex:495: anonymous fn/3 in Mix.Task.run_task/5
  (mix 1.17.3) lib/mix/task.ex:561: Mix.Task.run_alias/6
  (mix 1.17.3) lib/mix/cli.ex:96: Mix.CLI.run_task/2

warning: using map.field notation (without parentheses) to invoke function Firmware.Spec.examples() is deprecated, you must add parentheses instead: remote.function()
  (espec 1.9.2) lib/espec/suite_runner.ex:21: ESpec.SuiteRunner.run_module_examples/3
  (espec 1.9.2) lib/espec/suite_runner.ex:15: ESpec.SuiteRunner.run/3
  (elixir 1.17.3) lib/enum.ex:1703: Enum."-map/2-lists^map/1-1-"/2
  (espec 1.9.2) lib/espec/runner.ex:65: ESpec.Runner.run_suites/3
  (espec 1.9.2) lib/espec/runner.ex:38: ESpec.Runner.do_run/2
```